### PR TITLE
Bug fix and small schema change proposal

### DIFF
--- a/HybrasylIntegration/HybrasylXML/XSD/Creatures.cs
+++ b/HybrasylIntegration/HybrasylXML/XSD/Creatures.cs
@@ -40,6 +40,9 @@ namespace Hybrasyl.XSD
     {
         private Properties _properties;
 
+        [XmlAttributeAttribute("id")]
+        public ushort Id { get; set; }
+
         [XmlElementAttribute("name")]
         public string Name { get; set; }
 

--- a/HybrasylIntegration/HybrasylXML/XSD/Creatures.xsd
+++ b/HybrasylIntegration/HybrasylXML/XSD/Creatures.xsd
@@ -18,6 +18,7 @@
       <xs:element name="description" type="hyb:String8" minOccurs="0" maxOccurs="1" />
       <xs:element name="properties" type="creatures:Properties" minOccurs="0" maxOccurs="1" />
     </xs:sequence>
+    <xs:attribute name="id" type="xs:unsignedShort" use="required" />
     <xs:attribute name="sprite" use="required" type="xs:unsignedShort" />
   </xs:complexType>
 

--- a/HybrasylIntegration/HybrasylXML/XSD/Maps.cs
+++ b/HybrasylIntegration/HybrasylXML/XSD/Maps.cs
@@ -164,7 +164,8 @@ namespace Hybrasyl.XSD
             }
         }
 
-        [XmlArrayItemAttribute("spawn", IsNullable = false, ElementName = "spawns")]
+        [XmlArray("spawns")]
+        [XmlArrayItemAttribute("spawn", IsNullable = false, ElementName = "spawn")]
         public List<Spawn> Spawns
         {
             get
@@ -913,15 +914,12 @@ namespace Hybrasyl.XSD
     {
         private SpawnModifiers _spawnModifiers;
 
-        [XmlElementAttribute("name")]
-        public string Name { get; set; }
-
-        [XmlElementAttribute("description")]
-        public string Description { get; set; }
-
         [DefaultValueAttribute("random")]
         [XmlElementAttribute("strategy")]
         public string Strategy { get; set; }
+
+        [XmlAttributeAttribute(AttributeName = "mob")]
+        public int MobId { get; set; }
 
         [XmlAttributeAttribute(DataType = "nonNegativeInteger", AttributeName = "interval")]
         public string Interval { get; set; }

--- a/HybrasylIntegration/HybrasylXML/XSD/Maps.cs
+++ b/HybrasylIntegration/HybrasylXML/XSD/Maps.cs
@@ -914,12 +914,15 @@ namespace Hybrasyl.XSD
     {
         private SpawnModifiers _spawnModifiers;
 
+        [XmlElementAttribute("name")]
+        public string Name { get; set; }
+
+        [XmlElementAttribute("description")]
+        public string Description { get; set; }
+
         [DefaultValueAttribute("random")]
         [XmlElementAttribute("strategy")]
         public string Strategy { get; set; }
-
-        [XmlAttributeAttribute(AttributeName = "mob")]
-        public int MobId { get; set; }
 
         [XmlAttributeAttribute(DataType = "nonNegativeInteger", AttributeName = "interval")]
         public string Interval { get; set; }

--- a/HybrasylIntegration/HybrasylXML/XSD/Maps.xsd
+++ b/HybrasylIntegration/HybrasylXML/XSD/Maps.xsd
@@ -88,11 +88,10 @@
   <!-- Spawn subelement -->
   <xs:complexType name="Spawn">
     <xs:sequence>
-      <xs:element name="name" type="hyb:String8" minOccurs="1" maxOccurs="1" />
-      <xs:element name="description" type="hyb:String16" minOccurs="0" maxOccurs="1" />
       <xs:element name="strategy" type="hyb:String8" default="random" minOccurs="0" maxOccurs="1" />
       <xs:element name="spawnModifiers" type="maps:SpawnModifiers" minOccurs="0" maxOccurs="1" />
     </xs:sequence>
+    <xs:attribute name="mob" type="xs:int" use="required" />
     <xs:attribute name="interval" type="xs:nonNegativeInteger" />
     <xs:attribute name="checkInterval" type="xs:nonNegativeInteger" />
   </xs:complexType>

--- a/HybrasylIntegration/HybrasylXML/XSD/Maps.xsd
+++ b/HybrasylIntegration/HybrasylXML/XSD/Maps.xsd
@@ -88,10 +88,11 @@
   <!-- Spawn subelement -->
   <xs:complexType name="Spawn">
     <xs:sequence>
+      <xs:element name="name" type="hyb:String8" minOccurs="1" maxOccurs="1" />
+      <xs:element name="description" type="hyb:String16" minOccurs="0" maxOccurs="1" />
       <xs:element name="strategy" type="hyb:String8" default="random" minOccurs="0" maxOccurs="1" />
       <xs:element name="spawnModifiers" type="maps:SpawnModifiers" minOccurs="0" maxOccurs="1" />
     </xs:sequence>
-    <xs:attribute name="mob" type="xs:int" use="required" />
     <xs:attribute name="interval" type="xs:nonNegativeInteger" />
     <xs:attribute name="checkInterval" type="xs:nonNegativeInteger" />
   </xs:complexType>


### PR DESCRIPTION
**Bug fix:** maps now correctly load spawns.

**Proposal:** give mobs an id field and reference that id in maps, etc to reference the same monster type. Will allow multiple monsters to have the same name and also doesn't provide ambiguous name and descriptions for monsters on a spawn point. This deviates from the pattern currently being used for warps between maps but feels like it'll be safer in the long run. Thoughts?

Additionally after reviewing the Mob schema I think we may need to expand the available properties in order to properly generate monsters on the server. I'm not sure now to correctly populate things like `MaximumHp` and `MaximumMp` from the fields as things stand today. We can discuss in chat.

cc: @baughj @norrismiv 