### PR TITLE
XSD updates: Spawngroup / server handlers

### DIFF
--- a/HybrasylIntegration/HybrasylXML/XSD/Castables.cs
+++ b/HybrasylIntegration/HybrasylXML/XSD/Castables.cs
@@ -559,8 +559,8 @@ namespace Hybrasyl.XSD
         [XmlElementAttribute("heal", typeof(Heal))]
         public Heal Heal { get; set; }
 
-        [XmlElementAttribute("scriptname", typeof(string))]
-        public string ScriptName { get; set; }
+        [XmlElementAttribute("script", typeof(string))]
+        public string Script { get; set; }
 
         [XmlElementAttribute("sound", typeof(EffectsSound))]
         public EffectsSound Sound { get; set; }

--- a/HybrasylIntegration/HybrasylXML/XSD/Castables.xsd
+++ b/HybrasylIntegration/HybrasylXML/XSD/Castables.xsd
@@ -23,6 +23,19 @@
     </xs:restriction>
   </xs:simpleType>
 
+ <xs:simpleType name="SpellUseType">
+   <xs:restriction base="xs:token">
+     <xs:enumeration value="unusable"/>
+     <xs:enumeration value="prompt"/>
+     <xs:enumeration value="target"/>
+     <xs:enumeration value="fourdigit"/>
+     <xs:enumeration value="threedigit"/>
+     <xs:enumeration value="notarget"/>
+     <xs:enumeration value="twodigit"/>
+     <xs:enumeration value="onedigit"/>
+   </xs:restriction>
+ </xs:simpleType>
+  
  <!-- Element properties (adds belt / necklace) -->
  <xs:simpleType name="Element">
    <xs:restriction base="xs:token">
@@ -113,7 +126,7 @@
 
   <!-- Intent: What does the spell do, and whom does it affect? -->
   <xs:complexType name="Intent">
-    <xs:attribute name="isclick" type="xs:boolean" default="false" />
+    <xs:attribute name="usetype" type="actions:SpellUseType" default="notarget" use="optional"/>
     <xs:attribute name="radius" type="xs:unsignedByte" default="0" />
     <xs:attribute name="direction" type="actions:IntentDirection" default="front" />
     <xs:attribute name="target" type="actions:IntentTargetList" use="required" />

--- a/HybrasylIntegration/HybrasylXML/XSD/Castables.xsd
+++ b/HybrasylIntegration/HybrasylXML/XSD/Castables.xsd
@@ -302,7 +302,7 @@
           <xs:attribute name="id" type="xs:byte" use="required" />
         </xs:complexType>
       </xs:element>
-      <xs:element name="scriptname" minOccurs="0" maxOccurs="1" type="hyb:String8" />
+      <xs:element name="script" minOccurs="0" maxOccurs="1" type="hyb:String8" />
       <xs:element name="heal" minOccurs="0" maxOccurs="1" type="actions:Heal" />
       <xs:element name="damage" minOccurs="0" maxOccurs="1" type="actions:Damage" />
       <xs:element name="stateffects" minOccurs="0" maxOccurs="1" type="actions:StatEffects" />

--- a/HybrasylIntegration/HybrasylXML/XSD/Creatures.xsd
+++ b/HybrasylIntegration/HybrasylXML/XSD/Creatures.xsd
@@ -5,89 +5,106 @@
   <xs:documentation xml:lang="en">
     Hybrasyl Project - Hybrasyl XML Schema - Creatures (NPCs/mobs/drops)
     This file is subject to the same licenses as Project Hybrasyl.
-    (C) 2015 Project Hybrasyl (info@hybrasyl.com)
+    (C) 2016 Project Hybrasyl (info@hybrasyl.com)
     Written by Justin Baugh (baughj@hybrasyl.com)
   </xs:documentation>
 </xs:annotation>
 
 <xs:import schemaLocation="hybrasylTypes.xsd" namespace="http://www.hybrasyl.com/XML/HybrasylCommon" />
 
+  <!-- Base definition for a monster -->
   <xs:complexType name="Mob">
     <xs:sequence>
       <xs:element name="name" type="hyb:String8" minOccurs="1" maxOccurs="1" />
       <xs:element name="description" type="hyb:String8" minOccurs="0" maxOccurs="1" />
-      <xs:element name="properties" type="creatures:Properties" minOccurs="0" maxOccurs="1" />
     </xs:sequence>
     <xs:attribute name="sprite" use="required" type="xs:unsignedShort" />
   </xs:complexType>
 
-  <xs:complexType name="Drop">
-    <xs:choice minOccurs="1" maxOccurs="unbounded">
-      <xs:element name="item">
-        <xs:complexType>
-          <xs:simpleContent>
-            <xs:extension base="hyb:String8">
-              <xs:attribute name="minqty" type="xs:unsignedByte" default="1" />
-              <xs:attribute name="maxqty" type="xs:unsignedByte" default="1" />
-              <xs:attribute name="chance" type="xs:float" default="1.0" />
-              <xs:attribute name="variant" type="hyb:String8" default="none" />
-            </xs:extension>
-          </xs:simpleContent>
-        </xs:complexType>
-      </xs:element>
-      <xs:element name="gold">
-        <xs:complexType>
-          <xs:attribute name="minqty" type="xs:unsignedByte" default="1" />
-          <xs:attribute name="maxqty" type="xs:unsignedByte" default="1" />
-          <xs:attribute name="chance" type="xs:float" default="1.0" />
-        </xs:complexType>
-      </xs:element>
-    </xs:choice>
-  </xs:complexType>
+  <!-- Spawngroup -->
 
-  <xs:complexType name="Properties">
+  <xs:complexType name="Spawngroup">
     <xs:sequence>
-      <xs:element name="difficulty" minOccurs="0" maxOccurs="1">
-        <xs:complexType>
-          <xs:attribute name="level" type="xs:unsignedByte" use="required" />
-          <xs:attribute name="multiplier" type="xs:float" default="1.0" />
-          <xs:attribute name="speed" type="xs:float" default="1.0" />
-        </xs:complexType>
-      </xs:element>
-      <xs:element name="damage" minOccurs="0" maxOccurs="1">
-        <xs:complexType>
-          <xs:attribute name="min" type="xs:unsignedInt" use="required" />
-          <xs:attribute name="max" type="xs:unsignedInt" use="required" />
-          <xs:attribute name="element" type="hyb:Element" default="none" />
-        </xs:complexType>
-      </xs:element>
-      <xs:element name="defense" minOccurs="0" maxOccurs="1">
-        <xs:complexType>
-          <xs:attribute name="mr" type="xs:unsignedByte" default="1" />
-          <xs:attribute name="ac" type="xs:unsignedByte" use="required" />
-          <xs:attribute name="element" type="hyb:Element" default="none" />
-        </xs:complexType>
-      </xs:element>
-      <xs:element name="loot" minOccurs="0" maxOccurs="1" type="creatures:Loot" />
-      <xs:element name="scriptname" minOccurs="0" maxOccurs="1" />
+      <xs:element mape="maps" type="creature:MapList" minOccurs="1" maxOccurs="1"/>
+      <xs:element mape="spawns" type="creature:SpawnList" minOccurs="1" maxOccurs="1"/>
     </xs:sequence>
   </xs:complexType>
 
-  <xs:complexType name="Loot">
-    <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="dropset" type="hyb:String8" />
-      <xs:element name="drops" type="creatures:Drop" />
-    </xs:choice>
-    <xs:attribute name="exp" type="xs:unsignedInt" use="optional" default="0" />
-    <xs:attribute name="gold" type="xs:unsignedInt" use="optional" default="0" />
-  </xs:complexType>
-  <xs:complexType name="Dropset">
+  
+  <xs:complexType name="MapList">
     <xs:sequence>
-      <xs:element name="name" minOccurs="1" maxOccurs="1" type="hyb:String8" />
-      <xs:element name="drops" type="creatures:Drop" />
+      <xs:element name="maps" type="Creature:Map" minOccurs="1" maxOccurs="1"/>
     </xs:sequence>
   </xs:complexType>
 
-  <xs:element name="mob" type="creatures:Mob" />
-  <xs:element name="dropset" type="creatures:Dropset" />
-</xs:schema>
+  <!-- Maps in the spawngroup -->
+  <xs:complexType name="Map">
+    <xs:sequence>
+      <xs:element name="map" type="hyb:String8" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- List of spawns in a spawngroup -->
+  <xs:complexType name="SpawnList">
+    <xs:sequence>
+      <xs:element name="spawn" type="creature:Spawn" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- definition for a monster (mob variant)-->
+  <xs:complexType name="Spawn">
+    <xs:sequence>
+      <xs:element name="script" type="hyb:String8" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="intents" type="creature:IntentList" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="respawn" type="creature:Respawn" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="damage" type="creature:Damage" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="defense" type="creature:Defense" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="stats" type="creature:Stats" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="loot" type="creature:LootList" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="castables" type="creature:Castables" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="base" type="hyb:String8" use="required"/>
+  </xs:complexType>
+
+  <!-- List of intents -->
+  <xs:complexType name="IntentList">
+    <xs:sequence>
+      <xs:element name="npc" type="creature:Intent" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="player" type="creature:Intent" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="monster" type="creature:Intent" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- Spawn intent (hostile/friendly/etc) -->
+  <xs:complexType name="Intent">
+    <xs:simpleContent>
+      <xs:extension base="hyb:string8">
+        <xs:attribute base="hyb:IntentType" name="intent"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <!-- Spawns -->
+  <xs:complexType name="Spawns">
+    <xs:sequence>
+      <xs:element name="spawn" type="maps:Spawn" minOccurs="1" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="Respawn">
+  </xs:complexType>
+
+  <xs:complexType name="Damage">
+  </xs:complexType>
+
+  <xs:complexType name="Defense">
+  </xs:complexType>
+
+  <xs:complexType name="Stats">
+  </xs:complexType>
+
+  <xs:complexType name="LootList">
+  </xs:complexType>
+
+  <xs:complexType name="Castables">
+  </xs:complexType>

--- a/HybrasylIntegration/HybrasylXML/XSD/Creatures.xsd
+++ b/HybrasylIntegration/HybrasylXML/XSD/Creatures.xsd
@@ -32,28 +32,14 @@
   <!-- A list of maps a spawngroup controls-->
   <xs:complexType name="MapList">
     <xs:sequence>
-      <xs:element name="maps" type="creature:Map" minOccurs="1" maxOccurs="1"/>
-    </xs:sequence>
-  </xs:complexType>
-
-  <!-- Spawns -->
-  <xs:complexType name="Spawns">
-    <xs:sequence>
-      <xs:element name="spawn" type="creature:Spawn" minOccurs="1" maxOccurs="unbounded" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <!-- Maps in the spawngroup -->
-  <xs:complexType name="Map">
-    <xs:sequence>
       <xs:element name="map" type="hyb:String8" minOccurs="1" maxOccurs="unbounded"/>
     </xs:sequence>
   </xs:complexType>
 
-  <!-- List of spawns in a spawngroup -->
+  <!-- Spawns -->
   <xs:complexType name="SpawnList">
     <xs:sequence>
-      <xs:element name="spawn" type="creature:Spawn" minOccurs="1" maxOccurs="unbounded"/>
+      <xs:element name="spawn" type="creature:Spawn" minOccurs="1" maxOccurs="unbounded" />
     </xs:sequence>
   </xs:complexType>
 
@@ -132,7 +118,7 @@
 
   <!-- Stats of a creature (only HP supported for now) -->
   <xs:complexType name="Stats">
-    <xs:attribute name="hp" type="xs:unsignedInt" default="0" use="optional"/>
+    <xs:attribute name="hp" type="xs:unsignedInt" use="required"/>
   </xs:complexType>
 
   <!-- List of loot tables which can be defined <table> or imported from external sources <import> -->

--- a/HybrasylIntegration/HybrasylXML/XSD/Creatures.xsd
+++ b/HybrasylIntegration/HybrasylXML/XSD/Creatures.xsd
@@ -1,16 +1,16 @@
 <?xml version="1.0"?>
-<xs:schema xmlns:hyb="http://www.hybrasyl.com/XML/HybrasylCommon" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:creatures="http://www.hybrasyl.com/XML/Creatures" targetNamespace="http://www.hybrasyl.com/XML/Creatures" elementFormDefault="qualified">
+<xs:schema xmlns:hyb="http://www.hybrasyl.com/XML/HybrasylCommon" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:creature="http://www.hybrasyl.com/XML/Creature" targetNamespace="http://www.hybrasyl.com/XML/Creature" elementFormDefault="qualified">
 
-<xs:annotation>
-  <xs:documentation xml:lang="en">
-    Hybrasyl Project - Hybrasyl XML Schema - Creatures (NPCs/mobs/drops)
-    This file is subject to the same licenses as Project Hybrasyl.
-    (C) 2016 Project Hybrasyl (info@hybrasyl.com)
-    Written by Justin Baugh (baughj@hybrasyl.com)
-  </xs:documentation>
-</xs:annotation>
+  <xs:annotation>
+    <xs:documentation xml:lang="en">
+      Hybrasyl Project - Hybrasyl XML Schema - Creatures (NPCs/mobs/drops)
+      This file is subject to the same licenses as Project Hybrasyl.
+      (C) 2016 Project Hybrasyl (info@hybrasyl.com)
+      Written by Justin Baugh (baughj@hybrasyl.com)
+    </xs:documentation>
+  </xs:annotation>
 
-<xs:import schemaLocation="hybrasylTypes.xsd" namespace="http://www.hybrasyl.com/XML/HybrasylCommon" />
+  <xs:import schemaLocation="hybrasylTypes.xsd" namespace="http://www.hybrasyl.com/XML/HybrasylCommon" />
 
   <!-- Base definition for a monster -->
   <xs:complexType name="Mob">
@@ -22,18 +22,24 @@
   </xs:complexType>
 
   <!-- Spawngroup -->
-
   <xs:complexType name="Spawngroup">
     <xs:sequence>
-      <xs:element mape="maps" type="creature:MapList" minOccurs="1" maxOccurs="1"/>
-      <xs:element mape="spawns" type="creature:SpawnList" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="maps" type="creature:MapList" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="spawns" type="creature:SpawnList" minOccurs="1" maxOccurs="1"/>
     </xs:sequence>
   </xs:complexType>
 
-  
+  <!-- A list of maps a spawngroup controls-->
   <xs:complexType name="MapList">
     <xs:sequence>
-      <xs:element name="maps" type="Creature:Map" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="maps" type="creature:Map" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- Spawns -->
+  <xs:complexType name="Spawns">
+    <xs:sequence>
+      <xs:element name="spawn" type="creature:Spawn" minOccurs="1" maxOccurs="unbounded" />
     </xs:sequence>
   </xs:complexType>
 
@@ -51,19 +57,36 @@
     </xs:sequence>
   </xs:complexType>
 
-  <!-- definition for a monster (mob variant)-->
+  <!-- Definition for an actual spawn/monster (mob variant)-->
   <xs:complexType name="Spawn">
     <xs:sequence>
-      <xs:element name="script" type="hyb:String8" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="script" type="creature:CreatureScript" minOccurs="0" maxOccurs="1"/>
       <xs:element name="intents" type="creature:IntentList" minOccurs="0" maxOccurs="1"/>
       <xs:element name="respawn" type="creature:Respawn" minOccurs="1" maxOccurs="1"/>
       <xs:element name="damage" type="creature:Damage" minOccurs="1" maxOccurs="1"/>
       <xs:element name="defense" type="creature:Defense" minOccurs="1" maxOccurs="1"/>
       <xs:element name="stats" type="creature:Stats" minOccurs="1" maxOccurs="1"/>
       <xs:element name="loot" type="creature:LootList" minOccurs="1" maxOccurs="1"/>
-      <xs:element name="castables" type="creature:Castables" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="castables" type="creature:CastableList" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
     <xs:attribute name="base" type="hyb:String8" use="required"/>
+  </xs:complexType>
+
+  <!-- Whether or not a specified script overrides the spawning behavior or supplements it-->
+  <xs:simpleType name="ScriptType">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="override"/>
+      <xs:enumeration value="supplement"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- Creature script name -->
+  <xs:complexType name="CreatureScript">
+    <xs:simpleContent>
+      <xs:extension base="hyb:String8">
+        <xs:attribute type="creature:ScriptType" name="type"/>
+      </xs:extension>
+    </xs:simpleContent>
   </xs:complexType>
 
   <!-- List of intents -->
@@ -78,33 +101,108 @@
   <!-- Spawn intent (hostile/friendly/etc) -->
   <xs:complexType name="Intent">
     <xs:simpleContent>
-      <xs:extension base="hyb:string8">
-        <xs:attribute base="hyb:IntentType" name="intent"/>
+      <xs:extension base="hyb:String8">
+        <xs:attribute type="hyb:IntentType" name="intent"/>
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
 
-  <!-- Spawns -->
-  <xs:complexType name="Spawns">
+  <!-- Respawn information (how often, min/max, percentage as a function of all mobs on a map -->
+  <xs:complexType name="Respawn">
+    <xs:attribute name="interval" type="xs:int" default="30" use="optional"/>
+    <xs:attribute name="min" type="xs:int" default="1" use="optional"/>
+    <xs:attribute name="max" type="xs:int" use="optional"/>
+    <xs:attribute name="percentage" type="xs:float" use="optional"/>
+  </xs:complexType>
+
+  <!-- Damage a spawn can do (min/max, element, type (physical/magical etc)) -->
+  <xs:complexType name="Damage">
+    <xs:attribute name="min" type="xs:int" default="1" use="optional"/>
+    <xs:attribute name="max" type="xs:int" use="required"/>
+    <xs:attribute name="element" type="hyb:Element" default="none" use="optional"/>
+    <xs:attribute name="type" type="hyb:DamageType" default="physical" use="optional"/>
+  </xs:complexType>
+
+  <!-- A creature's defense, including element, magic resistance and armor class -->
+  <xs:complexType name="Defense">
+    <xs:attribute name="mr" type="xs:int" default="0" use="optional"/>
+    <xs:attribute name="ac" type="xs:int" use="required"/>
+    <xs:attribute name="element" type="hyb:Element" default="none" use="optional"/>
+  </xs:complexType>
+
+  <!-- Stats of a creature (only HP supported for now) -->
+  <xs:complexType name="Stats">
+    <xs:attribute name="hp" type="xs:unsignedInt" default="0" use="optional"/>
+  </xs:complexType>
+
+  <!-- List of loot tables which can be defined <table> or imported from external sources <import> -->
+  <xs:complexType name="LootList">
+    <xs:choice minOccurs="1" maxOccurs="unbounded">
+      <xs:element name="import" type="creature:LootImport" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="table" type="creature:LootTable" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:choice>
+    <xs:attribute name="xp" type="xs:unsignedInt" default="0" use="optional" />
+    <xs:attribute name="gold" type="xs:unsignedInt" default="0" use="optional" />
+  </xs:complexType>
+
+  <!-- Imported loot table-->
+  <xs:complexType name="LootImport">
+    <xs:simpleContent>
+      <xs:extension base="hyb:String8">
+        <xs:attribute name="rolls" type="xs:int" default="1" use="optional"/>
+        <xs:attribute name="probability" type="xs:float" default="1" use="optional"/>
+        <xs:attribute name="override" type="xs:boolean" default="false" use="optional"/>
+        <xs:attribute name="always" type="xs:boolean" default="false" use="optional"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <!-- Locally defined loot table-->
+  <xs:complexType name="LootTable">
     <xs:sequence>
-      <xs:element name="spawn" type="maps:Spawn" minOccurs="1" maxOccurs="unbounded" />
+      <xs:element name="item" type="creature:LootItem" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="gold" type="creature:LootGold" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="rolls" type="xs:int" default="1" use="optional"/>
+    <xs:attribute name="probability" type="xs:float" default="1" use="optional"/>
+    <xs:attribute name="name" type="hyb:String8" default="false" use="optional"/>
+    <xs:attribute name="always" type="xs:boolean" default="false" use="optional"/>
+  </xs:complexType>
+
+  <!-- An item defined in a loot table-->
+  <xs:complexType name="LootItem">
+    <xs:simpleContent>
+      <xs:extension base="hyb:String8">
+        <xs:attribute name="min" type="xs:int" default="1" use="optional"/>
+        <xs:attribute name="max" type="xs:int" default="1" use="optional"/>
+        <xs:attribute name="unique" type="xs:boolean" default="false" use="optional"/>
+        <xs:attribute name="always" type="xs:boolean" default="false" use="optional"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <!-- Amount of gold defined in a loot table, in addition to any base gold defined in <loot> -->
+  <xs:complexType name="LootGold">
+    <xs:attribute name="min" type="xs:int" default="1" use="optional"/>
+    <xs:attribute name="max" type="xs:int" default="1" use="optional"/>
+    <xs:attribute name="unique" type="xs:boolean" default="false" use="optional"/>
+  </xs:complexType>
+
+  <!-- List of castables a creature is allowed to use -->
+  <xs:complexType name="CastableList">
+    <xs:sequence>
+      <xs:element name="castable" type="creature:Castable" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
   </xs:complexType>
 
-  <xs:complexType name="Respawn">
+  <xs:complexType name="Castable">
+    <xs:simpleContent>
+      <xs:extension base="hyb:String8">
+        <xs:attribute name="cooldown" type="xs:int" default="1" use="optional"/>
+        <xs:attribute name="probability" type="xs:float" default="1" use="optional"/>
+        <xs:attribute name="always" type="xs:boolean" default="false" use="optional"/>
+      </xs:extension>
+    </xs:simpleContent>
   </xs:complexType>
-
-  <xs:complexType name="Damage">
-  </xs:complexType>
-
-  <xs:complexType name="Defense">
-  </xs:complexType>
-
-  <xs:complexType name="Stats">
-  </xs:complexType>
-
-  <xs:complexType name="LootList">
-  </xs:complexType>
-
-  <xs:complexType name="Castables">
-  </xs:complexType>
+  
+</xs:schema>

--- a/HybrasylIntegration/HybrasylXML/XSD/Items.cs
+++ b/HybrasylIntegration/HybrasylXML/XSD/Items.cs
@@ -1260,8 +1260,8 @@ namespace Hybrasyl.XSD
 
         private ItemPropertiesUseSound _sound;
 
-        [XmlElementAttribute("scriptname")]
-        public string Scriptname { get; set; }
+        [XmlElementAttribute("script")]
+        public string Script { get; set; }
 
         [XmlAttributeAttribute(AttributeName = "consumed")]
         [DefaultValueAttribute(true)]

--- a/HybrasylIntegration/HybrasylXML/XSD/Items.cs
+++ b/HybrasylIntegration/HybrasylXML/XSD/Items.cs
@@ -1268,7 +1268,7 @@ namespace Hybrasyl.XSD
         public bool Consumed { get; set; }
 
         [XmlIgnore()]
-        public bool ScriptnameSpecified { get; set; }
+        public bool ScriptSpecified { get; set; }
 
         [XmlIgnore()]
         public bool TeleportSpecified { get; set; }

--- a/HybrasylIntegration/HybrasylXML/XSD/Items.xsd
+++ b/HybrasylIntegration/HybrasylXML/XSD/Items.xsd
@@ -232,7 +232,7 @@
       <xs:element name="use" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="scriptname" type="xs:string" minOccurs="0" maxOccurs="1" />
+            <xs:element name="script" type="xs:string" minOccurs="0" maxOccurs="1" />
             <xs:element name="teleport" minOccurs="0" maxOccurs="1">
               <xs:complexType>
                 <xs:simpleContent>

--- a/HybrasylIntegration/HybrasylXML/XSD/Maps.cs
+++ b/HybrasylIntegration/HybrasylXML/XSD/Maps.cs
@@ -845,8 +845,8 @@ namespace Hybrasyl.XSD
         [XmlElementAttribute("description")]
         public string Description { get; set; }
 
-        [XmlElementAttribute("scriptname")]
-        public string Scriptname { get; set; }
+        [XmlElementAttribute("script")]
+        public string Script { get; set; }
 
         [XmlAttributeAttribute(AttributeName = "x")]
         public byte X { get; set; }
@@ -861,7 +861,7 @@ namespace Hybrasyl.XSD
         public bool DescriptionSpecified { get; set; }
 
         [XmlIgnore()]
-        public bool ScriptnameSpecified { get; set; }
+        public bool ScriptSpecified { get; set; }
 
         [XmlIgnore()]
         public bool XSpecified { get; set; }
@@ -881,8 +881,8 @@ namespace Hybrasyl.XSD
         [XmlElementAttribute("message")]
         public string Message { get; set; }
 
-        [XmlElementAttribute("scriptname")]
-        public string Scriptname { get; set; }
+        [XmlElementAttribute("script")]
+        public string Script { get; set; }
 
         [XmlAttributeAttribute(AttributeName = "x")]
         public byte X { get; set; }
@@ -894,7 +894,7 @@ namespace Hybrasyl.XSD
         public bool MessageSpecified { get; set; }
 
         [XmlIgnore()]
-        public bool ScriptnameSpecified { get; set; }
+        public bool ScriptSpecified { get; set; }
 
         [XmlIgnore()]
         public bool XSpecified { get; set; }
@@ -1094,8 +1094,8 @@ namespace Hybrasyl.XSD
         [XmlElementAttribute("description")]
         public string Description { get; set; }
 
-        [XmlElementAttribute("scriptname")]
-        public string Scriptname { get; set; }
+        [XmlElementAttribute("script")]
+        public string Script { get; set; }
 
         [XmlAttributeAttribute(AttributeName = "x")]
         public byte X { get; set; }
@@ -1111,7 +1111,7 @@ namespace Hybrasyl.XSD
         public bool DescriptionSpecified { get; set; }
 
         [XmlIgnore()]
-        public bool ScriptnameSpecified { get; set; }
+        public bool ScriptSpecified { get; set; }
 
         [XmlIgnore()]
         public bool XSpecified { get; set; }

--- a/HybrasylIntegration/HybrasylXML/XSD/Maps.xsd
+++ b/HybrasylIntegration/HybrasylXML/XSD/Maps.xsd
@@ -45,7 +45,7 @@
   <xs:complexType name="Reactor">
     <xs:sequence>
       <xs:element name="description" type="hyb:String16" minOccurs="0" maxOccurs="1" />
-      <xs:element name="scriptname" type="hyb:String8" minOccurs="1" maxOccurs="1" />
+      <xs:element name="script" type="hyb:String8" minOccurs="1" maxOccurs="1" />
     </xs:sequence>
     <xs:attribute name="x" type="xs:unsignedByte" use="required" />
     <xs:attribute name="y" type="xs:unsignedByte" use="required" />
@@ -56,7 +56,7 @@
   <xs:complexType name="Signpost">
     <xs:sequence>
       <xs:element name="message" type="hyb:String16" minOccurs="1" maxOccurs="1" />
-      <xs:element name="scriptname" type="hyb:String8" minOccurs="0" maxOccurs="1" />
+      <xs:element name="script" type="hyb:String8" minOccurs="0" maxOccurs="1" />
     </xs:sequence>
     <xs:attribute name="x" type="xs:unsignedByte" use="required" />
     <xs:attribute name="y" type="xs:unsignedByte" use="required" />
@@ -67,7 +67,7 @@
     <xs:sequence>
       <xs:element name="name" type="hyb:String8" />
       <xs:element name="description" type="hyb:String16" />
-      <xs:element name="scriptname" type="hyb:String8" />
+      <xs:element name="script" type="hyb:String8" />
     </xs:sequence>
     <xs:attribute name="x" type="xs:unsignedByte" use="required" />
     <xs:attribute name="y" type="xs:unsignedByte" use="required" />

--- a/HybrasylIntegration/HybrasylXML/XSD/Maps.xsd
+++ b/HybrasylIntegration/HybrasylXML/XSD/Maps.xsd
@@ -52,51 +52,6 @@
     <xs:attribute name="blocking" default="false" type="xs:boolean" />
   </xs:complexType>
 
-  <!-- SpawnModifiers subelement block -->
-  <xs:complexType name="SpawnModifiers">
-    <xs:sequence>
-      <xs:element name="speed" type="xs:float" minOccurs="0" maxOccurs="1" />
-      <xs:element name="passive" minOccurs="0" maxOccurs="1" />
-      <xs:element name="quantity" minOccurs="0" maxOccurs="1">
-        <xs:complexType>
-          <xs:attribute name="min" type="xs:nonNegativeInteger" />
-          <xs:attribute name="max" type="xs:nonNegativeInteger" />
-          <xs:attribute name="percentage" type="xs:float" />
-        </xs:complexType>
-      </xs:element>
-      <xs:element name="zone" minOccurs="0" maxOccurs="unbounded">
-        <xs:complexType>
-          <xs:attribute name="start">
-            <xs:simpleType>
-              <xs:restriction base="xs:string">
-                <xs:pattern value="\d{0,3},\d{0,3}" />
-              </xs:restriction>
-            </xs:simpleType>
-          </xs:attribute>
-          <xs:attribute name="end">
-            <xs:simpleType>
-              <xs:restriction base="xs:string">
-                <xs:pattern value="\d{0,3},\d{0,3}" />
-              </xs:restriction>
-            </xs:simpleType>
-          </xs:attribute>
-        </xs:complexType>
-      </xs:element>
-    </xs:sequence>
-  </xs:complexType>
-
-  <!-- Spawn subelement -->
-  <xs:complexType name="Spawn">
-    <xs:sequence>
-      <xs:element name="name" type="hyb:String8" minOccurs="1" maxOccurs="1" />
-      <xs:element name="description" type="hyb:String16" minOccurs="0" maxOccurs="1" />
-      <xs:element name="strategy" type="hyb:String8" default="random" minOccurs="0" maxOccurs="1" />
-      <xs:element name="spawnModifiers" type="maps:SpawnModifiers" minOccurs="0" maxOccurs="1" />
-    </xs:sequence>
-    <xs:attribute name="interval" type="xs:nonNegativeInteger" />
-    <xs:attribute name="checkInterval" type="xs:nonNegativeInteger" />
-  </xs:complexType>
-
   <!-- Signpost subelements -->
   <xs:complexType name="Signpost">
     <xs:sequence>
@@ -135,13 +90,6 @@
     </xs:sequence>
   </xs:complexType>
 
-  <!-- Spawns -->
-  <xs:complexType name="Spawns">
-    <xs:sequence>
-      <xs:element name="spawn" type="maps:Spawn" minOccurs="1" maxOccurs="unbounded" />
-    </xs:sequence>
-  </xs:complexType>
-
   <!-- Warps -->
   <xs:complexType name="Warps">
     <xs:sequence>
@@ -165,7 +113,6 @@
       <xs:element name="warps" type="maps:Warps" minOccurs="0" maxOccurs="1" />
       <xs:element name="reactors" type="maps:Reactors" minOccurs="0" maxOccurs="1" />
       <xs:element name="npcs" type="maps:Npcs" minOccurs="0" maxOccurs="1" />
-      <xs:element name="spawns" type="maps:Spawns" minOccurs="0" maxOccurs="1" />
       <xs:element name="signposts" type="maps:Signposts" minOccurs="0" maxOccurs="1" />
     </xs:sequence>
     <xs:attribute name="id" type="xs:unsignedShort" use="required" />
@@ -210,24 +157,24 @@
 
   <!-- Worldmap point -->
   <xs:complexType name="WorldMapPoint">
-          <xs:sequence>
-            <xs:element name="description" minOccurs="0" maxOccurs="1" type="hyb:String8" />
-            <xs:element name="name" minOccurs="1" maxOccurs="1" type="hyb:String8" />
-            <xs:element name="target" minOccurs="1" maxOccurs="1">
-              <xs:complexType>
-                <xs:simpleContent>
-                  <xs:extension base="hyb:String8">
-                    <xs:attribute name="x" type="xs:unsignedByte" use="required" />
-                    <xs:attribute name="y" type="xs:unsignedByte" use="required" />
-                  </xs:extension>
-                </xs:simpleContent>
-              </xs:complexType>
-            </xs:element>
-            <xs:element name="restrictions" minOccurs="0" maxOccurs="1" type="hyb:WarpRestrictions" />
-          </xs:sequence>
-          <xs:attribute name="x" type="xs:unsignedShort" use="required" />
-          <xs:attribute name="y" type="xs:unsignedShort" use="required" />
+    <xs:sequence>
+      <xs:element name="description" minOccurs="0" maxOccurs="1" type="hyb:String8" />
+      <xs:element name="name" minOccurs="1" maxOccurs="1" type="hyb:String8" />
+      <xs:element name="target" minOccurs="1" maxOccurs="1">
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="hyb:String8">
+              <xs:attribute name="x" type="xs:unsignedByte" use="required" />
+              <xs:attribute name="y" type="xs:unsignedByte" use="required" />
+            </xs:extension>
+          </xs:simpleContent>
         </xs:complexType>
+      </xs:element>
+      <xs:element name="restrictions" minOccurs="0" maxOccurs="1" type="hyb:WarpRestrictions" />
+    </xs:sequence>
+    <xs:attribute name="x" type="xs:unsignedShort" use="required" />
+    <xs:attribute name="y" type="xs:unsignedShort" use="required" />
+  </xs:complexType>
 
   <!-- Worldmap points (collection of worldmap points) -->
   <xs:complexType name="WorldMapPoints">

--- a/HybrasylIntegration/HybrasylXML/XSD/hybrasylConfig.xsd
+++ b/HybrasylIntegration/HybrasylXML/XSD/hybrasylConfig.xsd
@@ -93,16 +93,10 @@
       <xs:element name="access" type="config:Access" minOccurs="0" maxOccurs="1" />
       <xs:element name="boards" type="config:GlobalBoards" minOccurs="0" maxOccurs="1" />
       <xs:element name="time" type="config:Time" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="handlers" type="config:Handlers" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:complexType>
-  <!--
-  <time>
-  <serverstart defaultage="Hybrasyl" defaultyear="1">2016-04-01T01:00:00Z</serverstart>
-  <ages>
-    <age name="Danaan" startdate="2016-04-01" startyear="1"/>
-  </ages>
-</time>
--->
+
   <xs:complexType name="Time">
     <xs:sequence>
       <xs:element name="ages" type="config:HybrasylAges" minOccurs="0" maxOccurs="1"/>
@@ -134,5 +128,51 @@
     </xs:sequence>
   </xs:complexType>
 
+  <xs:complexType name="Handlers">
+    <xs:sequence>
+      <xs:element name="death" minOccurs="0" maxOccurs="1" type="config:Death" />
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Death">
+    <xs:sequence>
+      <xs:element name="map" type="config:DeathMap" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="coma" type="config:DeathMap" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="penalty" type="config:DeathMap" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="legendmark" type="config:DeathMap" minOccurs="1" maxOccurs="1"/>
+
+    </xs:sequence>
+    <xs:attribute name="active" type="xs:boolean" default="true" use="optional"/>
+    <xs:attribute name="perishable" type="xs:boolean" default="true" use="optional"/>
+    <xs:attribute name="groupnotify" type="xs:boolean" default="true" use="optional"/>
+  </xs:complexType>
+
+  <xs:complexType name="DeathMap">
+    <xs:simpleContent>
+      <xs:extension base="hyb:String8">
+        <xs:attribute name="x" type="xs:byte" use="required"/>
+        <xs:attribute name="y" type="xs:byte" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  
+  <xs:complexType name="DeathComa">
+    <xs:attribute name="timeout" default="30" use="optional"/>  
+  </xs:complexType>
+  
+  <xs:complexType name="DeathPenalty">
+    <xs:attribute name="xp" type="xs:unsignedInt" default="5" use="optional"/>
+    <xs:attribute name="hp" type="xs:unsignedInt" default="5" use="optional"/>
+  </xs:complexType>
+
+  <xs:complexType name="DeathLegendMark">
+    <xs:simpleContent>
+      <xs:extension base="hyb:String8">
+        <xs:attribute name="prefix" type="hyb:String8" use="required"/>
+        <xs:attribute name="increment" type="xs:boolean" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  
   <xs:element name="hybrasylconfig" type="config:HybrasylConfig" />
 </xs:schema>

--- a/HybrasylIntegration/HybrasylXML/XSD/hybrasylConfig.xsd
+++ b/HybrasylIntegration/HybrasylXML/XSD/hybrasylConfig.xsd
@@ -137,9 +137,9 @@
   <xs:complexType name="Death">
     <xs:sequence>
       <xs:element name="map" type="config:DeathMap" minOccurs="1" maxOccurs="1"/>
-      <xs:element name="coma" type="config:DeathMap" minOccurs="1" maxOccurs="1"/>
-      <xs:element name="penalty" type="config:DeathMap" minOccurs="1" maxOccurs="1"/>
-      <xs:element name="legendmark" type="config:DeathMap" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="coma" type="config:DeathComa" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="penalty" type="config:DeathPenalty" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="legendmark" type="config:DeathLegendMark" minOccurs="1" maxOccurs="1"/>
 
     </xs:sequence>
     <xs:attribute name="active" type="xs:boolean" default="true" use="optional"/>

--- a/HybrasylIntegration/HybrasylXML/XSD/hybrasylTypes.xsd
+++ b/HybrasylIntegration/HybrasylXML/XSD/hybrasylTypes.xsd
@@ -166,6 +166,14 @@
     </xs:restriction>
   </xs:simpleType>
 
+  <xs:simpleType name="IntentType">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="hostile"/> <!-- Hostile to players and can be attacked -->
+      <xs:enumeration value="passive"/> <!-- Passive to players and cannot be attacked -->
+      <xs:enumeration value="neutral"/> <!-- Passive to players and can be attacked -->
+    </xs:restriction>
+  </xs:simpleType>
+
   <xs:simpleType name="WeaponType">
     <xs:restriction base="xs:token">
       <xs:enumeration value="onehand" />


### PR DESCRIPTION
This PR adds `<spawngroup>` as a new tag that defines spawn groups of mobs and is intended to live in `xml/creatures/spawngroups`. Loot tables can live either in individual spawngroup XML files, or in `xml/creatures/loot`, and base mobs go in `xml/creatures/mobs`.

This PR also adds `<handlers>` to the server configuration and `<death>` as its first handler, to tell the server what to do on player death. I am adding this in anticipation of removing all the hardcoded defaults I currently have on my branch.

Lastly, any map-based definition of spawns is removed.

@anyweez @norrismiv any additions I didn't remember to add here? 
