### PR TITLE
Add / expand status support in XML

### DIFF
--- a/HybrasylIntegration/HybrasylXML/XSD/Castables.Designer.cs
+++ b/HybrasylIntegration/HybrasylXML/XSD/Castables.Designer.cs
@@ -50,7 +50,7 @@ namespace Hybrasyl.Castables
         
         private Book _book;
         
-        private List<Element1> _element;
+        private List<Element> _element;
         
         private byte _lines;
         
@@ -63,7 +63,7 @@ namespace Hybrasyl.Castables
         public Castable()
         {
             this._class = new List<Class>();
-            this._element = new List<Element1>();
+            this._element = new List<Element>();
             this._effects = new Effects();
             this._restrictions = new Restrictions();
             this._requirements = new List<Requirement>();
@@ -228,7 +228,7 @@ namespace Hybrasyl.Castables
         }
         
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        public List<Element1> Element
+        public List<Element> Element
         {
             get
             {
@@ -375,6 +375,8 @@ namespace Hybrasyl.Castables
         
         private ushort _icon;
         
+        private string _name;
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public ushort Icon
         {
@@ -385,6 +387,19 @@ namespace Hybrasyl.Castables
             set
             {
                 this._icon = value;
+            }
+        }
+        
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string Name
+        {
+            get
+            {
+                return this._name;
+            }
+            set
+            {
+                this._name = value;
             }
         }
     }
@@ -826,7 +841,7 @@ namespace Hybrasyl.Castables
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/HybrasylCommon")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public enum Element
     {
         
@@ -2745,46 +2760,6 @@ namespace Hybrasyl.Castables
         
         /// <remarks/>
         UtilitySpell,
-    }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
-    [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(TypeName="Element", Namespace="http://www.hybrasyl.com/XML/Actions")]
-    public enum Element1
-    {
-        
-        /// <remarks/>
-        None,
-        
-        /// <remarks/>
-        Fire,
-        
-        /// <remarks/>
-        Water,
-        
-        /// <remarks/>
-        Wind,
-        
-        /// <remarks/>
-        Earth,
-        
-        /// <remarks/>
-        Light,
-        
-        /// <remarks/>
-        Dark,
-        
-        /// <remarks/>
-        Wood,
-        
-        /// <remarks/>
-        Metal,
-        
-        /// <remarks/>
-        Undead,
-        
-        /// <remarks/>
-        Random,
     }
 }
 #pragma warning restore

--- a/HybrasylIntegration/HybrasylXML/XSD/Castables.Designer.cs
+++ b/HybrasylIntegration/HybrasylXML/XSD/Castables.Designer.cs
@@ -15,55 +15,55 @@ namespace Hybrasyl.Castables
     using System.ComponentModel;
     using System.Xml;
     using System.Collections.Generic;
-
-
+    
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
-    [System.Xml.Serialization.XmlRootAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions", IsNullable = false)]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlRootAttribute(Namespace="http://www.hybrasyl.com/XML/Actions", IsNullable=false)]
     public partial class Castable
     {
-
+        
         private List<Description> _descriptions;
-
+        
         private string _name;
-
+        
         private Categories _categories;
-
+        
         private CastCostList _castCosts;
-
+        
         private List<Intent> _intents;
-
+        
         private MaxLevel _maxLevel;
-
+        
         private List<Requirement> _requirements;
-
+        
         private Restrictions _restrictions;
-
+        
         private Effects _effects;
-
+        
         private string _type;
-
+        
         private byte _icon;
-
+        
         private Book _book;
-
-        private List<Element> _element;
-
+        
+        private List<Element1> _element;
+        
         private byte _lines;
-
+        
         private List<Class> _class;
-
+        
         private int _cooldown;
-
+        
         private bool _isAssail;
-
+        
         public Castable()
         {
             this._class = new List<Class>();
-            this._element = new List<Element>();
+            this._element = new List<Element1>();
             this._effects = new Effects();
             this._restrictions = new Restrictions();
             this._requirements = new List<Requirement>();
@@ -76,8 +76,8 @@ namespace Hybrasyl.Castables
             this._cooldown = 0;
             this._isAssail = false;
         }
-
-        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable = false)]
+        
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
         public List<Description> Descriptions
         {
             get
@@ -89,7 +89,7 @@ namespace Hybrasyl.Castables
                 this._descriptions = value;
             }
         }
-
+        
         public string Name
         {
             get
@@ -101,7 +101,7 @@ namespace Hybrasyl.Castables
                 this._name = value;
             }
         }
-
+        
         public Categories Categories
         {
             get
@@ -113,7 +113,7 @@ namespace Hybrasyl.Castables
                 this._categories = value;
             }
         }
-
+        
         public CastCostList CastCosts
         {
             get
@@ -125,8 +125,8 @@ namespace Hybrasyl.Castables
                 this._castCosts = value;
             }
         }
-
-        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable = false)]
+        
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
         public List<Intent> Intents
         {
             get
@@ -138,7 +138,7 @@ namespace Hybrasyl.Castables
                 this._intents = value;
             }
         }
-
+        
         public MaxLevel MaxLevel
         {
             get
@@ -150,8 +150,8 @@ namespace Hybrasyl.Castables
                 this._maxLevel = value;
             }
         }
-
-        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable = false)]
+        
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
         public List<Requirement> Requirements
         {
             get
@@ -163,7 +163,7 @@ namespace Hybrasyl.Castables
                 this._requirements = value;
             }
         }
-
+        
         public Restrictions Restrictions
         {
             get
@@ -175,7 +175,7 @@ namespace Hybrasyl.Castables
                 this._restrictions = value;
             }
         }
-
+        
         public Effects Effects
         {
             get
@@ -187,7 +187,7 @@ namespace Hybrasyl.Castables
                 this._effects = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public string Type
         {
@@ -200,7 +200,7 @@ namespace Hybrasyl.Castables
                 this._type = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Icon
         {
@@ -213,7 +213,7 @@ namespace Hybrasyl.Castables
                 this._icon = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public Book Book
         {
@@ -226,9 +226,9 @@ namespace Hybrasyl.Castables
                 this._book = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        public List<Element> Element
+        public List<Element1> Element
         {
             get
             {
@@ -239,7 +239,7 @@ namespace Hybrasyl.Castables
                 this._element = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Lines
@@ -253,7 +253,7 @@ namespace Hybrasyl.Castables
                 this._lines = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<Class> Class
         {
@@ -266,7 +266,7 @@ namespace Hybrasyl.Castables
                 this._class = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(0)]
         public int Cooldown
@@ -280,7 +280,7 @@ namespace Hybrasyl.Castables
                 this._cooldown = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(false)]
         public bool IsAssail
@@ -295,24 +295,24 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class Description
     {
-
+        
         private List<Class> _class;
-
+        
         private string _value;
-
+        
         public Description()
         {
             this._class = new List<Class>();
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<Class> Class
         {
@@ -325,7 +325,7 @@ namespace Hybrasyl.Castables
                 this._class = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlTextAttribute()]
         public string Value
         {
@@ -339,258 +339,280 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/HybrasylCommon")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/HybrasylCommon")]
     public enum Class
     {
-
+        
         /// <remarks/>
         Peasant,
-
+        
         /// <remarks/>
         Warrior,
-
+        
         /// <remarks/>
         Rogue,
-
+        
         /// <remarks/>
         Wizard,
-
+        
         /// <remarks/>
         Priest,
-
+        
         /// <remarks/>
         Monk,
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    public partial class RemoveStatus
+    {
+        
+        private ushort _icon;
+        
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public ushort Icon
+        {
+            get
+            {
+                return this._icon;
+            }
+            set
+            {
+                this._icon = value;
+            }
+        }
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.SerializableAttribute()]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.ComponentModel.DesignerCategoryAttribute("code")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    public partial class StatusAnimation
+    {
+        
+        private ushort _targetEffect;
+        
+        private ushort _casterEffect;
+        
+        private string _message;
+        
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public ushort TargetEffect
+        {
+            get
+            {
+                return this._targetEffect;
+            }
+            set
+            {
+                this._targetEffect = value;
+            }
+        }
+        
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public ushort CasterEffect
+        {
+            get
+            {
+                return this._casterEffect;
+            }
+            set
+            {
+                this._casterEffect = value;
+            }
+        }
+        
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string Message
+        {
+            get
+            {
+                return this._message;
+            }
+            set
+            {
+                this._message = value;
+            }
+        }
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.SerializableAttribute()]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.ComponentModel.DesignerCategoryAttribute("code")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    public partial class StatusAnimations
+    {
+        
+        private StatusAnimation _onTick;
+        
+        private StatusAnimation _onStart;
+        
+        private StatusAnimation _onEnd;
+        
+        public StatusAnimation OnTick
+        {
+            get
+            {
+                return this._onTick;
+            }
+            set
+            {
+                this._onTick = value;
+            }
+        }
+        
+        public StatusAnimation OnStart
+        {
+            get
+            {
+                return this._onStart;
+            }
+            set
+            {
+                this._onStart = value;
+            }
+        }
+        
+        public StatusAnimation OnEnd
+        {
+            get
+            {
+                return this._onEnd;
+            }
+            set
+            {
+                this._onEnd = value;
+            }
+        }
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.SerializableAttribute()]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.ComponentModel.DesignerCategoryAttribute("code")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class AddStatus
     {
-
-        private float _modifier;
-
-        private DamageType _damageType;
-
-        private string _target;
-
-        private StatusEffectList _value;
-
+        
+        private List<StatEffect> _statEffect;
+        
+        private StatusAnimations _animations;
+        
+        private ushort _icon;
+        
+        private int _duration;
+        
+        private int _tick;
+        
+        [System.Xml.Serialization.XmlElementAttribute("StatEffect")]
+        public List<StatEffect> StatEffect
+        {
+            get
+            {
+                return this._statEffect;
+            }
+            set
+            {
+                this._statEffect = value;
+            }
+        }
+        
+        public StatusAnimations Animations
+        {
+            get
+            {
+                return this._animations;
+            }
+            set
+            {
+                this._animations = value;
+            }
+        }
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        public float Modifier
+        public ushort Icon
         {
             get
             {
-                return this._modifier;
+                return this._icon;
             }
             set
             {
-                this._modifier = value;
+                this._icon = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        public DamageType DamageType
+        public int Duration
         {
             get
             {
-                return this._damageType;
+                return this._duration;
             }
             set
             {
-                this._damageType = value;
+                this._duration = value;
             }
         }
-
-        [System.Xml.Serialization.XmlAttributeAttribute(DataType = "token")]
-        public string Target
+        
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public int Tick
         {
             get
             {
-                return this._target;
+                return this._tick;
             }
             set
             {
-                this._target = value;
-            }
-        }
-
-        [System.Xml.Serialization.XmlTextAttribute()]
-        public StatusEffectList Value
-        {
-            get
-            {
-                return this._value;
-            }
-            set
-            {
-                this._value = value;
+                this._tick = value;
             }
         }
     }
-
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
-    [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/HybrasylCommon")]
-    public enum DamageType
-    {
-
-        /// <remarks/>
-        Direct,
-
-        /// <remarks/>
-        Physical,
-
-        /// <remarks/>
-        Magical,
-
-        /// <remarks/>
-        Elemental,
-    }
-
-    [System.FlagsAttribute()]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
-    [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/HybrasylCommon")]
-    public enum StatusEffectList
-    {
-
-        /// <remarks/>
-        Freeze = 1,
-
-        /// <remarks/>
-        Sleep = 2,
-
-        /// <remarks/>
-        Paralyze = 4,
-
-        /// <remarks/>
-        Blind = 8,
-
-        /// <remarks/>
-        Skull = 16,
-
-        /// <remarks/>
-        Poison = 32,
-
-        /// <remarks/>
-        Mist = 64,
-
-        /// <remarks/>
-        Regen = 128,
-
-        /// <remarks/>
-        Sight = 256,
-
-        /// <remarks/>
-        Invisible = 512,
-
-        /// <remarks/>
-        Mute = 1024,
-
-        /// <remarks/>
-        ReflectPhysical = 2048,
-
-        /// <remarks/>
-        ReflectMagical = 4096,
-
-        /// <remarks/>
-        Invulnerable = 8192,
-
-        /// <remarks/>
-        Charm = 16384,
-
-        /// <remarks/>
-        IncreaseDamage = 32768,
-
-        /// <remarks/>
-        ReduceDamage = 65536,
-
-        /// <remarks/>
-        ProhibitUsage = 131072,
-
-        /// <remarks/>
-        AbsorbSpell = 262144,
-    }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
-    public partial class Statuses
-    {
-
-        private List<AddStatus> _add;
-
-        private List<string> _remove;
-
-        [System.Xml.Serialization.XmlElementAttribute("Add")]
-        public List<AddStatus> Add
-        {
-            get
-            {
-                return this._add;
-            }
-            set
-            {
-                this._add = value;
-            }
-        }
-
-        [System.Xml.Serialization.XmlElementAttribute("Remove")]
-        public List<string> Remove
-        {
-            get
-            {
-                return this._remove;
-            }
-            set
-            {
-                this._remove = value;
-            }
-        }
-    }
-
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
-    [System.SerializableAttribute()]
-    [System.Diagnostics.DebuggerStepThroughAttribute()]
-    [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class StatEffect
     {
-
+        
         private sbyte _str;
-
+        
         private sbyte _int;
-
+        
         private sbyte _wis;
-
+        
         private sbyte _con;
-
+        
         private sbyte _dex;
-
+        
         private int _hp;
-
+        
         private int _mp;
-
+        
         private sbyte _hit;
-
+        
         private sbyte _dmg;
-
+        
         private sbyte _ac;
-
+        
         private sbyte _regen;
-
+        
         private sbyte _mr;
-
-        private uint _duration;
-
+        
+        private Element _offensiveElement;
+        
+        private Element _defensiveElement;
+        
         public StatEffect()
         {
             this._str = ((sbyte)(0));
@@ -605,9 +627,8 @@ namespace Hybrasyl.Castables
             this._ac = ((sbyte)(0));
             this._regen = ((sbyte)(0));
             this._mr = ((sbyte)(0));
-            this._duration = ((uint)(0));
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Str
@@ -621,7 +642,7 @@ namespace Hybrasyl.Castables
                 this._str = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Int
@@ -635,7 +656,7 @@ namespace Hybrasyl.Castables
                 this._int = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Wis
@@ -649,7 +670,7 @@ namespace Hybrasyl.Castables
                 this._wis = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Con
@@ -663,7 +684,7 @@ namespace Hybrasyl.Castables
                 this._con = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Dex
@@ -677,7 +698,7 @@ namespace Hybrasyl.Castables
                 this._dex = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(0)]
         public int Hp
@@ -691,7 +712,7 @@ namespace Hybrasyl.Castables
                 this._hp = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(0)]
         public int Mp
@@ -705,7 +726,7 @@ namespace Hybrasyl.Castables
                 this._mp = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Hit
@@ -719,7 +740,7 @@ namespace Hybrasyl.Castables
                 this._hit = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Dmg
@@ -733,7 +754,7 @@ namespace Hybrasyl.Castables
                 this._dmg = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Ac
@@ -747,7 +768,7 @@ namespace Hybrasyl.Castables
                 this._ac = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Regen
@@ -761,7 +782,7 @@ namespace Hybrasyl.Castables
                 this._regen = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Mr
@@ -775,47 +796,138 @@ namespace Hybrasyl.Castables
                 this._mr = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        [System.ComponentModel.DefaultValueAttribute(typeof(uint), "0")]
-        public uint Duration
+        public Element OffensiveElement
         {
             get
             {
-                return this._duration;
+                return this._offensiveElement;
             }
             set
             {
-                this._duration = value;
+                this._offensiveElement = value;
+            }
+        }
+        
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public Element DefensiveElement
+        {
+            get
+            {
+                return this._defensiveElement;
+            }
+            set
+            {
+                this._defensiveElement = value;
             }
         }
     }
-
+    
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.SerializableAttribute()]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/HybrasylCommon")]
+    public enum Element
+    {
+        
+        /// <remarks/>
+        None,
+        
+        /// <remarks/>
+        Fire,
+        
+        /// <remarks/>
+        Water,
+        
+        /// <remarks/>
+        Wind,
+        
+        /// <remarks/>
+        Earth,
+        
+        /// <remarks/>
+        Light,
+        
+        /// <remarks/>
+        Dark,
+        
+        /// <remarks/>
+        Wood,
+        
+        /// <remarks/>
+        Metal,
+        
+        /// <remarks/>
+        Undead,
+        
+        /// <remarks/>
+        Random,
+    }
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    public partial class Statuses
+    {
+        
+        private List<AddStatus> _add;
+        
+        private List<RemoveStatus> _remove;
+        
+        [System.Xml.Serialization.XmlElementAttribute("Add")]
+        public List<AddStatus> Add
+        {
+            get
+            {
+                return this._add;
+            }
+            set
+            {
+                this._add = value;
+            }
+        }
+        
+        [System.Xml.Serialization.XmlElementAttribute("Remove")]
+        public List<RemoveStatus> Remove
+        {
+            get
+            {
+                return this._remove;
+            }
+            set
+            {
+                this._remove = value;
+            }
+        }
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.SerializableAttribute()]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.ComponentModel.DesignerCategoryAttribute("code")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class Damage
     {
-
+        
         private DamageFlags _flags;
-
+        
         private SimpleQuantity _simple;
-
+        
         private string _formula;
-
+        
         private bool _timeBased;
-
+        
         private uint _duration;
-
+        
         private DamageType _type;
-
+        
         public Damage()
         {
             this._simple = new SimpleQuantity();
         }
-
+        
         public DamageFlags Flags
         {
             get
@@ -827,7 +939,7 @@ namespace Hybrasyl.Castables
                 this._flags = value;
             }
         }
-
+        
         public SimpleQuantity Simple
         {
             get
@@ -839,7 +951,7 @@ namespace Hybrasyl.Castables
                 this._simple = value;
             }
         }
-
+        
         public string Formula
         {
             get
@@ -851,7 +963,7 @@ namespace Hybrasyl.Castables
                 this._formula = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public bool TimeBased
         {
@@ -864,7 +976,7 @@ namespace Hybrasyl.Castables
                 this._timeBased = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public uint Duration
         {
@@ -877,7 +989,7 @@ namespace Hybrasyl.Castables
                 this._duration = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public DamageType Type
         {
@@ -891,43 +1003,43 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.FlagsAttribute()]
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.hybrasyl.com/XML/Actions")]
     public enum DamageFlags
     {
-
+        
         /// <remarks/>
         Scaled = 1,
-
+        
         /// <remarks/>
         Resistance = 2,
-
+        
         /// <remarks/>
         Threat = 4,
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class SimpleQuantity
     {
-
+        
         private string _min;
-
+        
         private string _max;
-
+        
         public SimpleQuantity()
         {
             this._min = "0";
             this._max = "0";
         }
-
-        [System.Xml.Serialization.XmlAttributeAttribute(DataType = "nonNegativeInteger")]
+        
+        [System.Xml.Serialization.XmlAttributeAttribute(DataType="nonNegativeInteger")]
         [System.ComponentModel.DefaultValueAttribute("0")]
         public string Min
         {
@@ -940,8 +1052,8 @@ namespace Hybrasyl.Castables
                 this._min = value;
             }
         }
-
-        [System.Xml.Serialization.XmlAttributeAttribute(DataType = "nonNegativeInteger")]
+        
+        [System.Xml.Serialization.XmlAttributeAttribute(DataType="nonNegativeInteger")]
         [System.ComponentModel.DefaultValueAttribute("0")]
         public string Max
         {
@@ -955,28 +1067,47 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.SerializableAttribute()]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/HybrasylCommon")]
+    public enum DamageType
+    {
+        
+        /// <remarks/>
+        Direct,
+        
+        /// <remarks/>
+        Physical,
+        
+        /// <remarks/>
+        Magical,
+        
+        /// <remarks/>
+        Elemental,
+    }
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class Heal
     {
-
+        
         private SimpleQuantity _simple;
-
+        
         private string _formula;
-
+        
         private bool _timeBased;
-
+        
         private uint _duration;
-
+        
         public Heal()
         {
             this._simple = new SimpleQuantity();
         }
-
+        
         public SimpleQuantity Simple
         {
             get
@@ -988,7 +1119,7 @@ namespace Hybrasyl.Castables
                 this._simple = value;
             }
         }
-
+        
         public string Formula
         {
             get
@@ -1000,7 +1131,7 @@ namespace Hybrasyl.Castables
                 this._formula = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public bool TimeBased
         {
@@ -1013,7 +1144,7 @@ namespace Hybrasyl.Castables
                 this._timeBased = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public uint Duration
         {
@@ -1027,26 +1158,26 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class AnimationDuration
     {
-
+        
         private ushort _id;
-
+        
         private ushort _speed;
-
+        
         private uint _tick;
-
+        
         public AnimationDuration()
         {
             this._speed = ((ushort)(100));
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public ushort Id
         {
@@ -1059,7 +1190,7 @@ namespace Hybrasyl.Castables
                 this._id = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(ushort), "100")]
         public ushort Speed
@@ -1073,7 +1204,7 @@ namespace Hybrasyl.Castables
                 this._speed = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public uint Tick
         {
@@ -1087,21 +1218,21 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class AnimationDurationGroup
     {
-
+        
         private AnimationDuration _player;
-
+        
         private AnimationDuration _spellEffect;
-
+        
         private AnimationDuration _target;
-
+        
         public AnimationDuration Player
         {
             get
@@ -1113,7 +1244,7 @@ namespace Hybrasyl.Castables
                 this._player = value;
             }
         }
-
+        
         public AnimationDuration SpellEffect
         {
             get
@@ -1125,7 +1256,7 @@ namespace Hybrasyl.Castables
                 this._spellEffect = value;
             }
         }
-
+        
         public AnimationDuration Target
         {
             get
@@ -1138,24 +1269,24 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class Animation
     {
-
+        
         private ushort _id;
-
+        
         private ushort _speed;
-
+        
         public Animation()
         {
             this._speed = ((ushort)(100));
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public ushort Id
         {
@@ -1168,7 +1299,7 @@ namespace Hybrasyl.Castables
                 this._id = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(ushort), "100")]
         public ushort Speed
@@ -1183,26 +1314,26 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class Motion
     {
-
+        
         private List<Class> _class;
-
+        
         private int _id;
-
+        
         private int _speed;
-
+        
         public Motion()
         {
             this._class = new List<Class>();
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<Class> Class
         {
@@ -1215,7 +1346,7 @@ namespace Hybrasyl.Castables
                 this._class = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public int Id
         {
@@ -1228,7 +1359,7 @@ namespace Hybrasyl.Castables
                 this._id = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public int Speed
         {
@@ -1242,22 +1373,22 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class AnimationGroup
     {
-
+        
         private List<Motion> _motions;
-
+        
         private Animation _spellEffect;
-
+        
         private Animation _target;
-
-        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable = false)]
+        
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
         public List<Motion> Motions
         {
             get
@@ -1269,7 +1400,7 @@ namespace Hybrasyl.Castables
                 this._motions = value;
             }
         }
-
+        
         public Animation SpellEffect
         {
             get
@@ -1281,7 +1412,7 @@ namespace Hybrasyl.Castables
                 this._spellEffect = value;
             }
         }
-
+        
         public Animation Target
         {
             get
@@ -1294,21 +1425,21 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class Animations
     {
-
+        
         private AnimationGroup _onCast;
-
+        
         private AnimationDurationGroup _duration;
-
+        
         private AnimationGroup _end;
-
+        
         public AnimationGroup OnCast
         {
             get
@@ -1320,7 +1451,7 @@ namespace Hybrasyl.Castables
                 this._onCast = value;
             }
         }
-
+        
         public AnimationDurationGroup Duration
         {
             get
@@ -1332,7 +1463,7 @@ namespace Hybrasyl.Castables
                 this._duration = value;
             }
         }
-
+        
         public AnimationGroup End
         {
             get
@@ -1345,36 +1476,36 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class Effects
     {
-
+        
         private Animations _animations;
-
+        
         private EffectsSound _sound;
-
+        
         private string _script;
-
+        
         private Heal _heal;
-
+        
         private Damage _damage;
-
+        
         private List<StatEffect> _statEffects;
-
+        
         private Statuses _statuses;
-
+        
         private uint _duration;
-
+        
         public Effects()
         {
             this._statuses = new Statuses();
         }
-
+        
         public Animations Animations
         {
             get
@@ -1386,7 +1517,7 @@ namespace Hybrasyl.Castables
                 this._animations = value;
             }
         }
-
+        
         public EffectsSound Sound
         {
             get
@@ -1398,7 +1529,7 @@ namespace Hybrasyl.Castables
                 this._sound = value;
             }
         }
-
+        
         public string Script
         {
             get
@@ -1410,7 +1541,7 @@ namespace Hybrasyl.Castables
                 this._script = value;
             }
         }
-
+        
         public Heal Heal
         {
             get
@@ -1422,7 +1553,7 @@ namespace Hybrasyl.Castables
                 this._heal = value;
             }
         }
-
+        
         public Damage Damage
         {
             get
@@ -1434,8 +1565,8 @@ namespace Hybrasyl.Castables
                 this._damage = value;
             }
         }
-
-        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable = false)]
+        
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
         public List<StatEffect> StatEffects
         {
             get
@@ -1447,7 +1578,7 @@ namespace Hybrasyl.Castables
                 this._statEffects = value;
             }
         }
-
+        
         public Statuses Statuses
         {
             get
@@ -1459,7 +1590,7 @@ namespace Hybrasyl.Castables
                 this._statuses = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public uint Duration
         {
@@ -1473,17 +1604,17 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class EffectsSound
     {
-
+        
         private byte _id;
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Id
         {
@@ -1497,25 +1628,25 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class Restrictions
     {
-
+        
         private List<WeaponType> _weaponType;
-
+        
         private List<EquipmentSlot> _equipType;
-
+        
         public Restrictions()
         {
             this._equipType = new List<EquipmentSlot>();
             this._weaponType = new List<WeaponType>();
         }
-
+        
         [System.Xml.Serialization.XmlElementAttribute("WeaponType")]
         public List<WeaponType> WeaponType
         {
@@ -1528,7 +1659,7 @@ namespace Hybrasyl.Castables
                 this._weaponType = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlElementAttribute("EquipType")]
         public List<EquipmentSlot> EquipType
         {
@@ -1542,116 +1673,116 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/HybrasylCommon")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/HybrasylCommon")]
     public enum WeaponType
     {
-
+        
         /// <remarks/>
         OneHand,
-
+        
         /// <remarks/>
         TwoHand,
-
+        
         /// <remarks/>
         Dagger,
-
+        
         /// <remarks/>
         Staff,
-
+        
         /// <remarks/>
         Claw,
-
+        
         /// <remarks/>
         None,
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/HybrasylCommon")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/HybrasylCommon")]
     public enum EquipmentSlot
     {
-
+        
         /// <remarks/>
         None,
-
+        
         /// <remarks/>
         Weapon,
-
+        
         /// <remarks/>
         Armor,
-
+        
         /// <remarks/>
         Shield,
-
+        
         /// <remarks/>
         Helmet,
-
+        
         /// <remarks/>
         Earring,
-
+        
         /// <remarks/>
         Necklace,
-
+        
         /// <remarks/>
         LeftHand,
-
+        
         /// <remarks/>
         RightHand,
-
+        
         /// <remarks/>
         LeftArm,
-
+        
         /// <remarks/>
         RightArm,
-
+        
         /// <remarks/>
         Waist,
-
+        
         /// <remarks/>
         Leg,
-
+        
         /// <remarks/>
         Foot,
-
+        
         /// <remarks/>
         FirstAcc,
-
+        
         /// <remarks/>
         Trousers,
-
+        
         /// <remarks/>
         Coat,
-
+        
         /// <remarks/>
         SecondAcc,
-
+        
         /// <remarks/>
         ThirdAcc,
-
+        
         /// <remarks/>
         Gauntlet,
-
+        
         /// <remarks/>
         Ring,
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class LearnPrerequisite
     {
-
+        
         private byte _level;
-
+        
         private byte _ab;
-
+        
         private string _value;
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Level
         {
@@ -1664,7 +1795,7 @@ namespace Hybrasyl.Castables
                 this._level = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Ab
         {
@@ -1677,7 +1808,7 @@ namespace Hybrasyl.Castables
                 this._ab = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlTextAttribute()]
         public string Value
         {
@@ -1691,33 +1822,33 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(Requirement))]
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class ClassRequirement
     {
-
+        
         private ClassRequirementLevel _level;
-
+        
         private ClassRequirementAB _ab;
-
+        
         private List<ItemSpecification> _items;
-
+        
         private uint _gold;
-
+        
         private ClassRequirementPhysical _physical;
-
+        
         private List<LearnPrerequisite> _prerequisites;
-
+        
         public ClassRequirement()
         {
             this._prerequisites = new List<LearnPrerequisite>();
         }
-
+        
         public ClassRequirementLevel Level
         {
             get
@@ -1729,7 +1860,7 @@ namespace Hybrasyl.Castables
                 this._level = value;
             }
         }
-
+        
         public ClassRequirementAB Ab
         {
             get
@@ -1741,8 +1872,8 @@ namespace Hybrasyl.Castables
                 this._ab = value;
             }
         }
-
-        [System.Xml.Serialization.XmlArrayItemAttribute("Item", IsNullable = false)]
+        
+        [System.Xml.Serialization.XmlArrayItemAttribute("Item", IsNullable=false)]
         public List<ItemSpecification> Items
         {
             get
@@ -1754,7 +1885,7 @@ namespace Hybrasyl.Castables
                 this._items = value;
             }
         }
-
+        
         public uint Gold
         {
             get
@@ -1766,7 +1897,7 @@ namespace Hybrasyl.Castables
                 this._gold = value;
             }
         }
-
+        
         public ClassRequirementPhysical Physical
         {
             get
@@ -1778,8 +1909,8 @@ namespace Hybrasyl.Castables
                 this._physical = value;
             }
         }
-
-        [System.Xml.Serialization.XmlArrayItemAttribute("Prerequisite", IsNullable = false)]
+        
+        [System.Xml.Serialization.XmlArrayItemAttribute("Prerequisite", IsNullable=false)]
         public List<LearnPrerequisite> Prerequisites
         {
             get
@@ -1792,25 +1923,25 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class ClassRequirementLevel
     {
-
+        
         private byte _min;
-
+        
         private byte _max;
-
+        
         public ClassRequirementLevel()
         {
             this._min = ((byte)(0));
             this._max = ((byte)(255));
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Min
@@ -1824,7 +1955,7 @@ namespace Hybrasyl.Castables
                 this._min = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "255")]
         public byte Max
@@ -1839,25 +1970,25 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class ClassRequirementAB
     {
-
+        
         private byte _min;
-
+        
         private byte _max;
-
+        
         public ClassRequirementAB()
         {
             this._min = ((byte)(0));
             this._max = ((byte)(255));
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Min
@@ -1871,7 +2002,7 @@ namespace Hybrasyl.Castables
                 this._min = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "255")]
         public byte Max
@@ -1886,24 +2017,24 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class ItemSpecification
     {
-
+        
         private byte _quantity;
-
+        
         private string _value;
-
+        
         public ItemSpecification()
         {
             this._quantity = ((byte)(1));
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "1")]
         public byte Quantity
@@ -1917,7 +2048,7 @@ namespace Hybrasyl.Castables
                 this._quantity = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlTextAttribute()]
         public string Value
         {
@@ -1931,29 +2062,29 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class ClassRequirementPhysical
     {
-
+        
         private byte _str;
-
+        
         private byte _int;
-
+        
         private byte _wis;
-
+        
         private byte _con;
-
+        
         private byte _dex;
-
+        
         private uint _hp;
-
+        
         private uint _mp;
-
+        
         public ClassRequirementPhysical()
         {
             this._str = ((byte)(0));
@@ -1964,7 +2095,7 @@ namespace Hybrasyl.Castables
             this._hp = ((uint)(0));
             this._mp = ((uint)(0));
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Str
@@ -1978,7 +2109,7 @@ namespace Hybrasyl.Castables
                 this._str = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Int
@@ -1992,7 +2123,7 @@ namespace Hybrasyl.Castables
                 this._int = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Wis
@@ -2006,7 +2137,7 @@ namespace Hybrasyl.Castables
                 this._wis = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Con
@@ -2020,7 +2151,7 @@ namespace Hybrasyl.Castables
                 this._con = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Dex
@@ -2034,7 +2165,7 @@ namespace Hybrasyl.Castables
                 this._dex = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(uint), "0")]
         public uint Hp
@@ -2048,7 +2179,7 @@ namespace Hybrasyl.Castables
                 this._hp = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(uint), "0")]
         public uint Mp
@@ -2063,22 +2194,22 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class Requirement : ClassRequirement
     {
-
+        
         private List<Class> _class;
-
+        
         public Requirement()
         {
             this._class = new List<Class>();
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<Class> Class
         {
@@ -2092,27 +2223,27 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class MaxLevel
     {
-
+        
         private byte _monk;
-
+        
         private byte _warrior;
-
+        
         private byte _peasant;
-
+        
         private byte _wizard;
-
+        
         private byte _priest;
-
+        
         private byte _rogue;
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Monk
         {
@@ -2125,7 +2256,7 @@ namespace Hybrasyl.Castables
                 this._monk = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Warrior
         {
@@ -2138,7 +2269,7 @@ namespace Hybrasyl.Castables
                 this._warrior = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Peasant
         {
@@ -2151,7 +2282,7 @@ namespace Hybrasyl.Castables
                 this._peasant = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Wizard
         {
@@ -2164,7 +2295,7 @@ namespace Hybrasyl.Castables
                 this._wizard = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Priest
         {
@@ -2177,7 +2308,7 @@ namespace Hybrasyl.Castables
                 this._priest = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Rogue
         {
@@ -2191,25 +2322,25 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class Intent
     {
-
+        
         private SpellUseType _useType;
-
+        
         private byte _radius;
-
+        
         private IntentDirection _direction;
-
+        
         private List<IntentTarget> _target;
-
+        
         private byte _maxTargets;
-
+        
         public Intent()
         {
             this._target = new List<IntentTarget>();
@@ -2218,7 +2349,7 @@ namespace Hybrasyl.Castables
             this._direction = IntentDirection.Front;
             this._maxTargets = ((byte)(0));
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(SpellUseType.NoTarget)]
         public SpellUseType UseType
@@ -2232,7 +2363,7 @@ namespace Hybrasyl.Castables
                 this._useType = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Radius
@@ -2246,7 +2377,7 @@ namespace Hybrasyl.Castables
                 this._radius = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(IntentDirection.Front)]
         public IntentDirection Direction
@@ -2260,7 +2391,7 @@ namespace Hybrasyl.Castables
                 this._direction = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<IntentTarget> Target
         {
@@ -2273,7 +2404,7 @@ namespace Hybrasyl.Castables
                 this._target = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte MaxTargets
@@ -2288,95 +2419,95 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public enum SpellUseType
     {
-
+        
         /// <remarks/>
         Unusable,
-
+        
         /// <remarks/>
         Prompt,
-
+        
         /// <remarks/>
         Target,
-
+        
         /// <remarks/>
         FourDigit,
-
+        
         /// <remarks/>
         ThreeDigit,
-
+        
         /// <remarks/>
         NoTarget,
-
+        
         /// <remarks/>
         TwoDigit,
-
+        
         /// <remarks/>
         Onedigit,
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public enum IntentDirection
     {
-
+        
         /// <remarks/>
         Front,
-
+        
         /// <remarks/>
         Back,
-
+        
         /// <remarks/>
         Left,
-
+        
         /// <remarks/>
         Right,
-
+        
         /// <remarks/>
         Nearby,
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public enum IntentTarget
     {
-
+        
         /// <remarks/>
         Hostile,
-
+        
         /// <remarks/>
         Friendly,
-
+        
         /// <remarks/>
         Pvp,
-
+        
         /// <remarks/>
         Group,
     }
-
+    
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(CastCost))]
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class ClassCastCost
     {
-
+        
         private List<ItemSpecification> _items;
-
+        
         private ClassCastCostStat _stat;
-
+        
         private uint _gold;
-
-        [System.Xml.Serialization.XmlArrayItemAttribute("Item", IsNullable = false)]
+        
+        [System.Xml.Serialization.XmlArrayItemAttribute("Item", IsNullable=false)]
         public List<ItemSpecification> Items
         {
             get
@@ -2388,7 +2519,7 @@ namespace Hybrasyl.Castables
                 this._items = value;
             }
         }
-
+        
         public ClassCastCostStat Stat
         {
             get
@@ -2400,7 +2531,7 @@ namespace Hybrasyl.Castables
                 this._stat = value;
             }
         }
-
+        
         public uint Gold
         {
             get
@@ -2413,25 +2544,25 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class ClassCastCostStat
     {
-
+        
         private string _hp;
-
+        
         private string _mp;
-
+        
         public ClassCastCostStat()
         {
             this._hp = "0";
             this._mp = "0";
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute("0")]
         public string Hp
@@ -2445,7 +2576,7 @@ namespace Hybrasyl.Castables
                 this._hp = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute("0")]
         public string Mp
@@ -2460,22 +2591,22 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class CastCost : ClassCastCost
     {
-
+        
         private List<Class> _class;
-
+        
         public CastCost()
         {
             this._class = new List<Class>();
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<Class> Class
         {
@@ -2489,22 +2620,22 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class CastCostList
     {
-
+        
         private CastCost _castCost;
-
+        
         public CastCostList()
         {
             this._castCost = new CastCost();
         }
-
+        
         public CastCost CastCost
         {
             get
@@ -2517,24 +2648,24 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class Category
     {
-
+        
         private bool _unique;
-
+        
         private string _value;
-
+        
         public Category()
         {
             this._unique = false;
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(false)]
         public bool Unique
@@ -2548,7 +2679,7 @@ namespace Hybrasyl.Castables
                 this._unique = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlTextAttribute()]
         public string Value
         {
@@ -2562,22 +2693,22 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class Categories
     {
-
+        
         private Category _category;
-
+        
         public Categories()
         {
             this._category = new Category();
         }
-
+        
         public Category Category
         {
             get
@@ -2590,68 +2721,68 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public enum Book
     {
-
+        
         /// <remarks/>
         PrimarySkill,
-
+        
         /// <remarks/>
         SecondarySkill,
-
+        
         /// <remarks/>
         UtilitySkill,
-
+        
         /// <remarks/>
         PrimarySpell,
-
+        
         /// <remarks/>
         SecondarySpell,
-
+        
         /// <remarks/>
         UtilitySpell,
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
-    public enum Element
+    [System.Xml.Serialization.XmlTypeAttribute(TypeName="Element", Namespace="http://www.hybrasyl.com/XML/Actions")]
+    public enum Element1
     {
-
+        
         /// <remarks/>
         None,
-
+        
         /// <remarks/>
         Fire,
-
+        
         /// <remarks/>
         Water,
-
+        
         /// <remarks/>
         Wind,
-
+        
         /// <remarks/>
         Earth,
-
+        
         /// <remarks/>
         Light,
-
+        
         /// <remarks/>
         Dark,
-
+        
         /// <remarks/>
         Wood,
-
+        
         /// <remarks/>
         Metal,
-
+        
         /// <remarks/>
         Undead,
-
+        
         /// <remarks/>
         Random,
     }

--- a/HybrasylIntegration/HybrasylXML/XSD/Castables.xsd
+++ b/HybrasylIntegration/HybrasylXML/XSD/Castables.xsd
@@ -416,21 +416,9 @@
     <xs:attribute name="Tick" type="xs:int" use="required"/>
   </xs:complexType>
 
-  <!--
-  <Statuses>
-<Add Icon="3" Duration="600" Tick="3">
-  <Animations>
-    <OnTick Effect="6" Message="You are fucked"/>
-    <OnStart .../>
-    <OnEnd .../>
-  </Animations>
-  <StatEffect></StatEffect>
-</Add>
-</Statuses>
--->
-
   <xs:complexType name="RemoveStatus">
     <xs:attribute name="Icon" type="xs:unsignedShort" />
+    <xs:attribute name="Name" type="hyb:String8"/>
   </xs:complexType>
   
   <xs:complexType name="Statuses">
@@ -460,8 +448,8 @@
     <xs:attribute name="Ac" default="0" type="xs:byte" />
     <xs:attribute name="Regen" default="0" type="xs:byte" />
     <xs:attribute name="Mr" default="0" type="xs:byte" />
-    <xs:attribute name="OffensiveElement" type="hyb:Element"/>
-    <xs:attribute name="DefensiveElement" type="hyb:Element"/>
+    <xs:attribute name="OffensiveElement" type="actions:Element"/>
+    <xs:attribute name="DefensiveElement" type="actions:Element"/>
   </xs:complexType>
 
   <!-- Restrictions on casting, such as types of equipment, or

--- a/HybrasylIntegration/HybrasylXML/XSD/Castables.xsd
+++ b/HybrasylIntegration/HybrasylXML/XSD/Castables.xsd
@@ -378,13 +378,6 @@
     <xs:attribute name="Duration" type="xs:unsignedInt" />
   </xs:complexType>
 
-  <xs:complexType name="Statuses">
-    <xs:sequence minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="Add" type="actions:AddStatus" minOccurs="0" maxOccurs="unbounded" />
-      <xs:element name="Remove" type="hyb:String8" minOccurs="0" maxOccurs="unbounded" />
-    </xs:sequence>
-  </xs:complexType>
-
   <xs:complexType name="Categories">
     <xs:sequence minOccurs="0" maxOccurs="1">
       <xs:element name="Category" type="actions:Category"/>
@@ -399,16 +392,54 @@
     </xs:simpleContent>
   </xs:complexType>
 
-  <xs:complexType name="AddStatus">
-     <xs:simpleContent>
-       <xs:extension base="hyb:StatusEffectList">
-         <xs:attribute name="Modifier" type="xs:float" use="optional" />
-         <xs:attribute name="DamageType" type="hyb:DamageType" use="optional" />
-         <xs:attribute name="Target" type="xs:token" use="optional" />
-       </xs:extension>
-     </xs:simpleContent>
+  <xs:complexType name="StatusAnimations">
+    <xs:sequence>
+      <xs:element name="OnTick" type="actions:StatusAnimation" minOccurs="0" maxOccurs="1" />
+      <xs:element name="OnStart" type="actions:StatusAnimation" minOccurs="0" maxOccurs="1" />
+      <xs:element name="OnEnd" type="actions:StatusAnimation" minOccurs="0" maxOccurs="1" />
+    </xs:sequence>
   </xs:complexType>
 
+  <xs:complexType name="StatusAnimation">
+    <xs:attribute name="TargetEffect" type="xs:unsignedShort" use="optional"/>
+    <xs:attribute name="CasterEffect" type="xs:unsignedShort" use="optional"/>
+    <xs:attribute name="Message" type="hyb:String8" use="optional"/>
+  </xs:complexType>
+    
+  <xs:complexType name="AddStatus">
+    <xs:sequence>
+      <xs:element name="StatEffect" type="actions:StatEffect" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="Animations" type="actions:StatusAnimations" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="Icon" type="xs:unsignedShort" use="required"/>
+    <xs:attribute name="Duration" type="xs:int" use="required"/>
+    <xs:attribute name="Tick" type="xs:int" use="required"/>
+  </xs:complexType>
+
+  <!--
+  <Statuses>
+<Add Icon="3" Duration="600" Tick="3">
+  <Animations>
+    <OnTick Effect="6" Message="You are fucked"/>
+    <OnStart .../>
+    <OnEnd .../>
+  </Animations>
+  <StatEffect></StatEffect>
+</Add>
+</Statuses>
+-->
+
+  <xs:complexType name="RemoveStatus">
+    <xs:attribute name="Icon" type="xs:unsignedShort" />
+  </xs:complexType>
+  
+  <xs:complexType name="Statuses">
+    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="Add" type="actions:AddStatus" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="Remove" type="actions:RemoveStatus" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+  
   <!-- Stat effects (buffs or debuffs) container element -->
   <xs:complexType name="StatEffects">
     <xs:sequence minOccurs="1" maxOccurs="unbounded">
@@ -429,7 +460,8 @@
     <xs:attribute name="Ac" default="0" type="xs:byte" />
     <xs:attribute name="Regen" default="0" type="xs:byte" />
     <xs:attribute name="Mr" default="0" type="xs:byte" />
-    <xs:attribute name="Duration" default="0" type="xs:unsignedInt" />
+    <xs:attribute name="OffensiveElement" type="hyb:Element"/>
+    <xs:attribute name="DefensiveElement" type="hyb:Element"/>
   </xs:complexType>
 
   <!-- Restrictions on casting, such as types of equipment, or


### PR DESCRIPTION
Rather than requiring users to define Python scripts for all and sundry buff/debuffs, it makes a little more sense to support the creation of simple stat effect statuses in XML. This will greatly simplify existing use cases as probably about 90% of effects are currently simple status changes (+/- AC/MR/hit/etc etc).

There's probably room here for a `DamageEffect` / `HealEffect` as well which could be used to change the types of damage and/or modify damage or healing by a fixed modifier, but for right now, this will do.