### PR TITLE
Status updates

### DIFF
--- a/HybrasylIntegration/HybrasylXML/XSD/Castables.Designer.cs
+++ b/HybrasylIntegration/HybrasylXML/XSD/Castables.Designer.cs
@@ -15,51 +15,53 @@ namespace Hybrasyl.Castables
     using System.ComponentModel;
     using System.Xml;
     using System.Collections.Generic;
-    
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
-    [System.Xml.Serialization.XmlRootAttribute(Namespace="http://www.hybrasyl.com/XML/Actions", IsNullable=false)]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlRootAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions", IsNullable = false)]
     public partial class Castable
     {
-        
+
         private List<Description> _descriptions;
-        
+
         private string _name;
-        
+
         private Categories _categories;
-        
+
         private CastCostList _castCosts;
-        
+
         private List<Intent> _intents;
-        
+
         private MaxLevel _maxLevel;
-        
+
         private List<Requirement> _requirements;
-        
+
         private Restrictions _restrictions;
-        
+
         private Effects _effects;
-        
+
+        private string _script;
+
         private string _type;
-        
+
         private byte _icon;
-        
+
         private Book _book;
-        
+
         private List<Element> _element;
-        
+
         private byte _lines;
-        
+
         private List<Class> _class;
-        
+
         private int _cooldown;
-        
+
         private bool _isAssail;
-        
+
         public Castable()
         {
             this._class = new List<Class>();
@@ -76,8 +78,8 @@ namespace Hybrasyl.Castables
             this._cooldown = 0;
             this._isAssail = false;
         }
-        
-        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
+
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable = false)]
         public List<Description> Descriptions
         {
             get
@@ -89,7 +91,7 @@ namespace Hybrasyl.Castables
                 this._descriptions = value;
             }
         }
-        
+
         public string Name
         {
             get
@@ -101,7 +103,7 @@ namespace Hybrasyl.Castables
                 this._name = value;
             }
         }
-        
+
         public Categories Categories
         {
             get
@@ -113,7 +115,7 @@ namespace Hybrasyl.Castables
                 this._categories = value;
             }
         }
-        
+
         public CastCostList CastCosts
         {
             get
@@ -125,8 +127,8 @@ namespace Hybrasyl.Castables
                 this._castCosts = value;
             }
         }
-        
-        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
+
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable = false)]
         public List<Intent> Intents
         {
             get
@@ -138,7 +140,7 @@ namespace Hybrasyl.Castables
                 this._intents = value;
             }
         }
-        
+
         public MaxLevel MaxLevel
         {
             get
@@ -150,8 +152,8 @@ namespace Hybrasyl.Castables
                 this._maxLevel = value;
             }
         }
-        
-        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
+
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable = false)]
         public List<Requirement> Requirements
         {
             get
@@ -163,7 +165,7 @@ namespace Hybrasyl.Castables
                 this._requirements = value;
             }
         }
-        
+
         public Restrictions Restrictions
         {
             get
@@ -175,7 +177,7 @@ namespace Hybrasyl.Castables
                 this._restrictions = value;
             }
         }
-        
+
         public Effects Effects
         {
             get
@@ -187,7 +189,19 @@ namespace Hybrasyl.Castables
                 this._effects = value;
             }
         }
-        
+
+        public string Script
+        {
+            get
+            {
+                return this._script;
+            }
+            set
+            {
+                this._script = value;
+            }
+        }
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public string Type
         {
@@ -200,7 +214,7 @@ namespace Hybrasyl.Castables
                 this._type = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Icon
         {
@@ -213,7 +227,7 @@ namespace Hybrasyl.Castables
                 this._icon = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public Book Book
         {
@@ -226,7 +240,7 @@ namespace Hybrasyl.Castables
                 this._book = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<Element> Element
         {
@@ -239,7 +253,7 @@ namespace Hybrasyl.Castables
                 this._element = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Lines
@@ -253,7 +267,7 @@ namespace Hybrasyl.Castables
                 this._lines = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<Class> Class
         {
@@ -266,7 +280,7 @@ namespace Hybrasyl.Castables
                 this._class = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(0)]
         public int Cooldown
@@ -280,7 +294,7 @@ namespace Hybrasyl.Castables
                 this._cooldown = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(false)]
         public bool IsAssail
@@ -295,24 +309,24 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Description
     {
-        
+
         private List<Class> _class;
-        
+
         private string _value;
-        
+
         public Description()
         {
             this._class = new List<Class>();
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<Class> Class
         {
@@ -325,7 +339,7 @@ namespace Hybrasyl.Castables
                 this._class = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlTextAttribute()]
         public string Value
         {
@@ -339,44 +353,44 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/HybrasylCommon")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/HybrasylCommon")]
     public enum Class
     {
-        
+
         /// <remarks/>
         Peasant,
-        
+
         /// <remarks/>
         Warrior,
-        
+
         /// <remarks/>
         Rogue,
-        
+
         /// <remarks/>
         Wizard,
-        
+
         /// <remarks/>
         Priest,
-        
+
         /// <remarks/>
         Monk,
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class RemoveStatus
     {
-        
+
         private ushort _icon;
-        
+
         private string _name;
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public ushort Icon
         {
@@ -389,7 +403,7 @@ namespace Hybrasyl.Castables
                 this._icon = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public string Name
         {
@@ -403,21 +417,123 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    public partial class Conditions
+    {
+
+        private ConditionList _add;
+
+        private ConditionList _remove;
+
+        public ConditionList Add
+        {
+            get
+            {
+                return this._add;
+            }
+            set
+            {
+                this._add = value;
+            }
+        }
+
+        public ConditionList Remove
+        {
+            get
+            {
+                return this._remove;
+            }
+            set
+            {
+                this._remove = value;
+            }
+        }
+    }
+
+    [System.FlagsAttribute()]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
+    [System.SerializableAttribute()]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/HybrasylCommon")]
+    public enum ConditionList
+    {
+
+        /// <remarks/>
+        Freeze = 1,
+
+        /// <remarks/>
+        Sleep = 2,
+
+        /// <remarks/>
+        Paralyze = 4,
+
+        /// <remarks/>
+        Blind = 8,
+
+        /// <remarks/>
+        Coma = 16,
+
+        /// <remarks/>
+        Poison = 32,
+
+        /// <remarks/>
+        Mist = 64,
+
+        /// <remarks/>
+        Regen = 128,
+
+        /// <remarks/>
+        Sight = 256,
+
+        /// <remarks/>
+        Invisible = 512,
+
+        /// <remarks/>
+        Mute = 1024,
+
+        /// <remarks/>
+        ReflectPhysical = 2048,
+
+        /// <remarks/>
+        ReflectMagical = 4096,
+
+        /// <remarks/>
+        Invulnerable = 8192,
+
+        /// <remarks/>
+        Charm = 16384,
+
+        /// <remarks/>
+        IncreaseDamage = 32768,
+
+        /// <remarks/>
+        ReduceDamage = 65536,
+
+        /// <remarks/>
+        ProhibitUsage = 131072,
+
+        /// <remarks/>
+        AbsorbSpell = 262144,
+    }
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
+    [System.SerializableAttribute()]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.ComponentModel.DesignerCategoryAttribute("code")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class StatusAnimation
     {
-        
+
         private ushort _targetEffect;
-        
+
         private ushort _casterEffect;
-        
+
         private string _message;
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public ushort TargetEffect
         {
@@ -430,7 +546,7 @@ namespace Hybrasyl.Castables
                 this._targetEffect = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public ushort CasterEffect
         {
@@ -443,7 +559,7 @@ namespace Hybrasyl.Castables
                 this._casterEffect = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public string Message
         {
@@ -457,21 +573,21 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class StatusAnimations
     {
-        
+
         private StatusAnimation _onTick;
-        
+
         private StatusAnimation _onStart;
-        
+
         private StatusAnimation _onEnd;
-        
+
         public StatusAnimation OnTick
         {
             get
@@ -483,7 +599,7 @@ namespace Hybrasyl.Castables
                 this._onTick = value;
             }
         }
-        
+
         public StatusAnimation OnStart
         {
             get
@@ -495,7 +611,7 @@ namespace Hybrasyl.Castables
                 this._onStart = value;
             }
         }
-        
+
         public StatusAnimation OnEnd
         {
             get
@@ -508,25 +624,27 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class AddStatus
     {
-        
+
         private List<StatEffect> _statEffect;
-        
+
         private StatusAnimations _animations;
-        
+
+        private Conditions _conditions;
+
         private ushort _icon;
-        
+
         private int _duration;
-        
+
         private int _tick;
-        
+
         [System.Xml.Serialization.XmlElementAttribute("StatEffect")]
         public List<StatEffect> StatEffect
         {
@@ -539,7 +657,7 @@ namespace Hybrasyl.Castables
                 this._statEffect = value;
             }
         }
-        
+
         public StatusAnimations Animations
         {
             get
@@ -551,7 +669,19 @@ namespace Hybrasyl.Castables
                 this._animations = value;
             }
         }
-        
+
+        public Conditions Conditions
+        {
+            get
+            {
+                return this._conditions;
+            }
+            set
+            {
+                this._conditions = value;
+            }
+        }
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public ushort Icon
         {
@@ -564,7 +694,7 @@ namespace Hybrasyl.Castables
                 this._icon = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public int Duration
         {
@@ -577,7 +707,7 @@ namespace Hybrasyl.Castables
                 this._duration = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public int Tick
         {
@@ -591,43 +721,43 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class StatEffect
     {
-        
+
         private sbyte _str;
-        
+
         private sbyte _int;
-        
+
         private sbyte _wis;
-        
+
         private sbyte _con;
-        
+
         private sbyte _dex;
-        
+
         private int _hp;
-        
+
         private int _mp;
-        
+
         private sbyte _hit;
-        
+
         private sbyte _dmg;
-        
+
         private sbyte _ac;
-        
+
         private sbyte _regen;
-        
+
         private sbyte _mr;
-        
+
         private Element _offensiveElement;
-        
+
         private Element _defensiveElement;
-        
+
         public StatEffect()
         {
             this._str = ((sbyte)(0));
@@ -643,7 +773,7 @@ namespace Hybrasyl.Castables
             this._regen = ((sbyte)(0));
             this._mr = ((sbyte)(0));
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Str
@@ -657,7 +787,7 @@ namespace Hybrasyl.Castables
                 this._str = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Int
@@ -671,7 +801,7 @@ namespace Hybrasyl.Castables
                 this._int = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Wis
@@ -685,7 +815,7 @@ namespace Hybrasyl.Castables
                 this._wis = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Con
@@ -699,7 +829,7 @@ namespace Hybrasyl.Castables
                 this._con = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Dex
@@ -713,7 +843,7 @@ namespace Hybrasyl.Castables
                 this._dex = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(0)]
         public int Hp
@@ -727,7 +857,7 @@ namespace Hybrasyl.Castables
                 this._hp = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(0)]
         public int Mp
@@ -741,7 +871,7 @@ namespace Hybrasyl.Castables
                 this._mp = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Hit
@@ -755,7 +885,7 @@ namespace Hybrasyl.Castables
                 this._hit = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Dmg
@@ -769,7 +899,7 @@ namespace Hybrasyl.Castables
                 this._dmg = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Ac
@@ -783,7 +913,7 @@ namespace Hybrasyl.Castables
                 this._ac = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Regen
@@ -797,7 +927,7 @@ namespace Hybrasyl.Castables
                 this._regen = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Mr
@@ -811,7 +941,7 @@ namespace Hybrasyl.Castables
                 this._mr = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public Element OffensiveElement
         {
@@ -824,7 +954,7 @@ namespace Hybrasyl.Castables
                 this._offensiveElement = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public Element DefensiveElement
         {
@@ -838,59 +968,59 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public enum Element
     {
-        
+
         /// <remarks/>
         None,
-        
+
         /// <remarks/>
         Fire,
-        
+
         /// <remarks/>
         Water,
-        
+
         /// <remarks/>
         Wind,
-        
+
         /// <remarks/>
         Earth,
-        
+
         /// <remarks/>
         Light,
-        
+
         /// <remarks/>
         Dark,
-        
+
         /// <remarks/>
         Wood,
-        
+
         /// <remarks/>
         Metal,
-        
+
         /// <remarks/>
         Undead,
-        
+
         /// <remarks/>
         Random,
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Statuses
     {
-        
+
         private List<AddStatus> _add;
-        
+
         private List<RemoveStatus> _remove;
-        
+
         [System.Xml.Serialization.XmlElementAttribute("Add")]
         public List<AddStatus> Add
         {
@@ -903,7 +1033,7 @@ namespace Hybrasyl.Castables
                 this._add = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlElementAttribute("Remove")]
         public List<RemoveStatus> Remove
         {
@@ -917,32 +1047,32 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Damage
     {
-        
+
         private DamageFlags _flags;
-        
+
         private SimpleQuantity _simple;
-        
+
         private string _formula;
-        
+
         private bool _timeBased;
-        
+
         private uint _duration;
-        
+
         private DamageType _type;
-        
+
         public Damage()
         {
             this._simple = new SimpleQuantity();
         }
-        
+
         public DamageFlags Flags
         {
             get
@@ -954,7 +1084,7 @@ namespace Hybrasyl.Castables
                 this._flags = value;
             }
         }
-        
+
         public SimpleQuantity Simple
         {
             get
@@ -966,7 +1096,7 @@ namespace Hybrasyl.Castables
                 this._simple = value;
             }
         }
-        
+
         public string Formula
         {
             get
@@ -978,7 +1108,7 @@ namespace Hybrasyl.Castables
                 this._formula = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public bool TimeBased
         {
@@ -991,7 +1121,7 @@ namespace Hybrasyl.Castables
                 this._timeBased = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public uint Duration
         {
@@ -1004,7 +1134,7 @@ namespace Hybrasyl.Castables
                 this._duration = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public DamageType Type
         {
@@ -1018,43 +1148,43 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.FlagsAttribute()]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public enum DamageFlags
     {
-        
+
         /// <remarks/>
         Scaled = 1,
-        
+
         /// <remarks/>
         Resistance = 2,
-        
+
         /// <remarks/>
         Threat = 4,
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class SimpleQuantity
     {
-        
+
         private string _min;
-        
+
         private string _max;
-        
+
         public SimpleQuantity()
         {
             this._min = "0";
             this._max = "0";
         }
-        
-        [System.Xml.Serialization.XmlAttributeAttribute(DataType="nonNegativeInteger")]
+
+        [System.Xml.Serialization.XmlAttributeAttribute(DataType = "nonNegativeInteger")]
         [System.ComponentModel.DefaultValueAttribute("0")]
         public string Min
         {
@@ -1067,8 +1197,8 @@ namespace Hybrasyl.Castables
                 this._min = value;
             }
         }
-        
-        [System.Xml.Serialization.XmlAttributeAttribute(DataType="nonNegativeInteger")]
+
+        [System.Xml.Serialization.XmlAttributeAttribute(DataType = "nonNegativeInteger")]
         [System.ComponentModel.DefaultValueAttribute("0")]
         public string Max
         {
@@ -1082,47 +1212,47 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/HybrasylCommon")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/HybrasylCommon")]
     public enum DamageType
     {
-        
+
         /// <remarks/>
         Direct,
-        
+
         /// <remarks/>
         Physical,
-        
+
         /// <remarks/>
         Magical,
-        
+
         /// <remarks/>
         Elemental,
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Heal
     {
-        
+
         private SimpleQuantity _simple;
-        
+
         private string _formula;
-        
+
         private bool _timeBased;
-        
+
         private uint _duration;
-        
+
         public Heal()
         {
             this._simple = new SimpleQuantity();
         }
-        
+
         public SimpleQuantity Simple
         {
             get
@@ -1134,7 +1264,7 @@ namespace Hybrasyl.Castables
                 this._simple = value;
             }
         }
-        
+
         public string Formula
         {
             get
@@ -1146,7 +1276,7 @@ namespace Hybrasyl.Castables
                 this._formula = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public bool TimeBased
         {
@@ -1159,7 +1289,7 @@ namespace Hybrasyl.Castables
                 this._timeBased = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public uint Duration
         {
@@ -1173,26 +1303,26 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class AnimationDuration
     {
-        
+
         private ushort _id;
-        
+
         private ushort _speed;
-        
+
         private uint _tick;
-        
+
         public AnimationDuration()
         {
             this._speed = ((ushort)(100));
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public ushort Id
         {
@@ -1205,7 +1335,7 @@ namespace Hybrasyl.Castables
                 this._id = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(ushort), "100")]
         public ushort Speed
@@ -1219,7 +1349,7 @@ namespace Hybrasyl.Castables
                 this._speed = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public uint Tick
         {
@@ -1233,21 +1363,21 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class AnimationDurationGroup
     {
-        
+
         private AnimationDuration _player;
-        
+
         private AnimationDuration _spellEffect;
-        
+
         private AnimationDuration _target;
-        
+
         public AnimationDuration Player
         {
             get
@@ -1259,7 +1389,7 @@ namespace Hybrasyl.Castables
                 this._player = value;
             }
         }
-        
+
         public AnimationDuration SpellEffect
         {
             get
@@ -1271,7 +1401,7 @@ namespace Hybrasyl.Castables
                 this._spellEffect = value;
             }
         }
-        
+
         public AnimationDuration Target
         {
             get
@@ -1284,24 +1414,24 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Animation
     {
-        
+
         private ushort _id;
-        
+
         private ushort _speed;
-        
+
         public Animation()
         {
             this._speed = ((ushort)(100));
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public ushort Id
         {
@@ -1314,7 +1444,7 @@ namespace Hybrasyl.Castables
                 this._id = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(ushort), "100")]
         public ushort Speed
@@ -1329,26 +1459,26 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Motion
     {
-        
+
         private List<Class> _class;
-        
+
         private int _id;
-        
+
         private int _speed;
-        
+
         public Motion()
         {
             this._class = new List<Class>();
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<Class> Class
         {
@@ -1361,7 +1491,7 @@ namespace Hybrasyl.Castables
                 this._class = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public int Id
         {
@@ -1374,7 +1504,7 @@ namespace Hybrasyl.Castables
                 this._id = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public int Speed
         {
@@ -1388,22 +1518,22 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class AnimationGroup
     {
-        
+
         private List<Motion> _motions;
-        
+
         private Animation _spellEffect;
-        
+
         private Animation _target;
-        
-        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
+
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable = false)]
         public List<Motion> Motions
         {
             get
@@ -1415,7 +1545,7 @@ namespace Hybrasyl.Castables
                 this._motions = value;
             }
         }
-        
+
         public Animation SpellEffect
         {
             get
@@ -1427,7 +1557,7 @@ namespace Hybrasyl.Castables
                 this._spellEffect = value;
             }
         }
-        
+
         public Animation Target
         {
             get
@@ -1440,21 +1570,21 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Animations
     {
-        
+
         private AnimationGroup _onCast;
-        
+
         private AnimationDurationGroup _duration;
-        
+
         private AnimationGroup _end;
-        
+
         public AnimationGroup OnCast
         {
             get
@@ -1466,7 +1596,7 @@ namespace Hybrasyl.Castables
                 this._onCast = value;
             }
         }
-        
+
         public AnimationDurationGroup Duration
         {
             get
@@ -1478,7 +1608,7 @@ namespace Hybrasyl.Castables
                 this._duration = value;
             }
         }
-        
+
         public AnimationGroup End
         {
             get
@@ -1491,36 +1621,35 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Effects
     {
-        
+
         private Animations _animations;
-        
+
         private EffectsSound _sound;
-        
-        private string _script;
-        
+
         private Heal _heal;
-        
+
         private Damage _damage;
-        
+
         private List<StatEffect> _statEffects;
-        
+
         private Statuses _statuses;
-        
-        private uint _duration;
-        
+
+        private bool _scriptOverride;
+
         public Effects()
         {
             this._statuses = new Statuses();
+            this._scriptOverride = false;
         }
-        
+
         public Animations Animations
         {
             get
@@ -1532,7 +1661,7 @@ namespace Hybrasyl.Castables
                 this._animations = value;
             }
         }
-        
+
         public EffectsSound Sound
         {
             get
@@ -1544,19 +1673,7 @@ namespace Hybrasyl.Castables
                 this._sound = value;
             }
         }
-        
-        public string Script
-        {
-            get
-            {
-                return this._script;
-            }
-            set
-            {
-                this._script = value;
-            }
-        }
-        
+
         public Heal Heal
         {
             get
@@ -1568,7 +1685,7 @@ namespace Hybrasyl.Castables
                 this._heal = value;
             }
         }
-        
+
         public Damage Damage
         {
             get
@@ -1580,8 +1697,8 @@ namespace Hybrasyl.Castables
                 this._damage = value;
             }
         }
-        
-        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
+
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable = false)]
         public List<StatEffect> StatEffects
         {
             get
@@ -1593,7 +1710,7 @@ namespace Hybrasyl.Castables
                 this._statEffects = value;
             }
         }
-        
+
         public Statuses Statuses
         {
             get
@@ -1605,31 +1722,32 @@ namespace Hybrasyl.Castables
                 this._statuses = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        public uint Duration
+        [System.ComponentModel.DefaultValueAttribute(false)]
+        public bool ScriptOverride
         {
             get
             {
-                return this._duration;
+                return this._scriptOverride;
             }
             set
             {
-                this._duration = value;
+                this._scriptOverride = value;
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class EffectsSound
     {
-        
+
         private byte _id;
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Id
         {
@@ -1643,25 +1761,25 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Restrictions
     {
-        
+
         private List<WeaponType> _weaponType;
-        
+
         private List<EquipmentSlot> _equipType;
-        
+
         public Restrictions()
         {
             this._equipType = new List<EquipmentSlot>();
             this._weaponType = new List<WeaponType>();
         }
-        
+
         [System.Xml.Serialization.XmlElementAttribute("WeaponType")]
         public List<WeaponType> WeaponType
         {
@@ -1674,7 +1792,7 @@ namespace Hybrasyl.Castables
                 this._weaponType = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlElementAttribute("EquipType")]
         public List<EquipmentSlot> EquipType
         {
@@ -1688,116 +1806,116 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/HybrasylCommon")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/HybrasylCommon")]
     public enum WeaponType
     {
-        
+
         /// <remarks/>
         OneHand,
-        
+
         /// <remarks/>
         TwoHand,
-        
+
         /// <remarks/>
         Dagger,
-        
+
         /// <remarks/>
         Staff,
-        
+
         /// <remarks/>
         Claw,
-        
+
         /// <remarks/>
         None,
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/HybrasylCommon")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/HybrasylCommon")]
     public enum EquipmentSlot
     {
-        
+
         /// <remarks/>
         None,
-        
+
         /// <remarks/>
         Weapon,
-        
+
         /// <remarks/>
         Armor,
-        
+
         /// <remarks/>
         Shield,
-        
+
         /// <remarks/>
         Helmet,
-        
+
         /// <remarks/>
         Earring,
-        
+
         /// <remarks/>
         Necklace,
-        
+
         /// <remarks/>
         LeftHand,
-        
+
         /// <remarks/>
         RightHand,
-        
+
         /// <remarks/>
         LeftArm,
-        
+
         /// <remarks/>
         RightArm,
-        
+
         /// <remarks/>
         Waist,
-        
+
         /// <remarks/>
         Leg,
-        
+
         /// <remarks/>
         Foot,
-        
+
         /// <remarks/>
         FirstAcc,
-        
+
         /// <remarks/>
         Trousers,
-        
+
         /// <remarks/>
         Coat,
-        
+
         /// <remarks/>
         SecondAcc,
-        
+
         /// <remarks/>
         ThirdAcc,
-        
+
         /// <remarks/>
         Gauntlet,
-        
+
         /// <remarks/>
         Ring,
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class LearnPrerequisite
     {
-        
+
         private byte _level;
-        
+
         private byte _ab;
-        
+
         private string _value;
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Level
         {
@@ -1810,7 +1928,7 @@ namespace Hybrasyl.Castables
                 this._level = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Ab
         {
@@ -1823,7 +1941,7 @@ namespace Hybrasyl.Castables
                 this._ab = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlTextAttribute()]
         public string Value
         {
@@ -1837,33 +1955,33 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(Requirement))]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class ClassRequirement
     {
-        
+
         private ClassRequirementLevel _level;
-        
+
         private ClassRequirementAB _ab;
-        
+
         private List<ItemSpecification> _items;
-        
+
         private uint _gold;
-        
+
         private ClassRequirementPhysical _physical;
-        
+
         private List<LearnPrerequisite> _prerequisites;
-        
+
         public ClassRequirement()
         {
             this._prerequisites = new List<LearnPrerequisite>();
         }
-        
+
         public ClassRequirementLevel Level
         {
             get
@@ -1875,7 +1993,7 @@ namespace Hybrasyl.Castables
                 this._level = value;
             }
         }
-        
+
         public ClassRequirementAB Ab
         {
             get
@@ -1887,8 +2005,8 @@ namespace Hybrasyl.Castables
                 this._ab = value;
             }
         }
-        
-        [System.Xml.Serialization.XmlArrayItemAttribute("Item", IsNullable=false)]
+
+        [System.Xml.Serialization.XmlArrayItemAttribute("Item", IsNullable = false)]
         public List<ItemSpecification> Items
         {
             get
@@ -1900,7 +2018,7 @@ namespace Hybrasyl.Castables
                 this._items = value;
             }
         }
-        
+
         public uint Gold
         {
             get
@@ -1912,7 +2030,7 @@ namespace Hybrasyl.Castables
                 this._gold = value;
             }
         }
-        
+
         public ClassRequirementPhysical Physical
         {
             get
@@ -1924,8 +2042,8 @@ namespace Hybrasyl.Castables
                 this._physical = value;
             }
         }
-        
-        [System.Xml.Serialization.XmlArrayItemAttribute("Prerequisite", IsNullable=false)]
+
+        [System.Xml.Serialization.XmlArrayItemAttribute("Prerequisite", IsNullable = false)]
         public List<LearnPrerequisite> Prerequisites
         {
             get
@@ -1938,25 +2056,25 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class ClassRequirementLevel
     {
-        
+
         private byte _min;
-        
+
         private byte _max;
-        
+
         public ClassRequirementLevel()
         {
             this._min = ((byte)(0));
             this._max = ((byte)(255));
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Min
@@ -1970,7 +2088,7 @@ namespace Hybrasyl.Castables
                 this._min = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "255")]
         public byte Max
@@ -1985,25 +2103,25 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class ClassRequirementAB
     {
-        
+
         private byte _min;
-        
+
         private byte _max;
-        
+
         public ClassRequirementAB()
         {
             this._min = ((byte)(0));
             this._max = ((byte)(255));
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Min
@@ -2017,7 +2135,7 @@ namespace Hybrasyl.Castables
                 this._min = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "255")]
         public byte Max
@@ -2032,24 +2150,24 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class ItemSpecification
     {
-        
+
         private byte _quantity;
-        
+
         private string _value;
-        
+
         public ItemSpecification()
         {
             this._quantity = ((byte)(1));
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "1")]
         public byte Quantity
@@ -2063,7 +2181,7 @@ namespace Hybrasyl.Castables
                 this._quantity = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlTextAttribute()]
         public string Value
         {
@@ -2077,29 +2195,29 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class ClassRequirementPhysical
     {
-        
+
         private byte _str;
-        
+
         private byte _int;
-        
+
         private byte _wis;
-        
+
         private byte _con;
-        
+
         private byte _dex;
-        
+
         private uint _hp;
-        
+
         private uint _mp;
-        
+
         public ClassRequirementPhysical()
         {
             this._str = ((byte)(0));
@@ -2110,7 +2228,7 @@ namespace Hybrasyl.Castables
             this._hp = ((uint)(0));
             this._mp = ((uint)(0));
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Str
@@ -2124,7 +2242,7 @@ namespace Hybrasyl.Castables
                 this._str = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Int
@@ -2138,7 +2256,7 @@ namespace Hybrasyl.Castables
                 this._int = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Wis
@@ -2152,7 +2270,7 @@ namespace Hybrasyl.Castables
                 this._wis = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Con
@@ -2166,7 +2284,7 @@ namespace Hybrasyl.Castables
                 this._con = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Dex
@@ -2180,7 +2298,7 @@ namespace Hybrasyl.Castables
                 this._dex = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(uint), "0")]
         public uint Hp
@@ -2194,7 +2312,7 @@ namespace Hybrasyl.Castables
                 this._hp = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(uint), "0")]
         public uint Mp
@@ -2209,22 +2327,22 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Requirement : ClassRequirement
     {
-        
+
         private List<Class> _class;
-        
+
         public Requirement()
         {
             this._class = new List<Class>();
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<Class> Class
         {
@@ -2238,27 +2356,27 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class MaxLevel
     {
-        
+
         private byte _monk;
-        
+
         private byte _warrior;
-        
+
         private byte _peasant;
-        
+
         private byte _wizard;
-        
+
         private byte _priest;
-        
+
         private byte _rogue;
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Monk
         {
@@ -2271,7 +2389,7 @@ namespace Hybrasyl.Castables
                 this._monk = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Warrior
         {
@@ -2284,7 +2402,7 @@ namespace Hybrasyl.Castables
                 this._warrior = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Peasant
         {
@@ -2297,7 +2415,7 @@ namespace Hybrasyl.Castables
                 this._peasant = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Wizard
         {
@@ -2310,7 +2428,7 @@ namespace Hybrasyl.Castables
                 this._wizard = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Priest
         {
@@ -2323,7 +2441,7 @@ namespace Hybrasyl.Castables
                 this._priest = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Rogue
         {
@@ -2337,25 +2455,25 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Intent
     {
-        
+
         private SpellUseType _useType;
-        
+
         private byte _radius;
-        
+
         private IntentDirection _direction;
-        
+
         private List<IntentTarget> _target;
-        
+
         private byte _maxTargets;
-        
+
         public Intent()
         {
             this._target = new List<IntentTarget>();
@@ -2364,7 +2482,7 @@ namespace Hybrasyl.Castables
             this._direction = IntentDirection.Front;
             this._maxTargets = ((byte)(0));
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(SpellUseType.NoTarget)]
         public SpellUseType UseType
@@ -2378,7 +2496,7 @@ namespace Hybrasyl.Castables
                 this._useType = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Radius
@@ -2392,7 +2510,7 @@ namespace Hybrasyl.Castables
                 this._radius = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(IntentDirection.Front)]
         public IntentDirection Direction
@@ -2406,7 +2524,7 @@ namespace Hybrasyl.Castables
                 this._direction = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<IntentTarget> Target
         {
@@ -2419,7 +2537,7 @@ namespace Hybrasyl.Castables
                 this._target = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte MaxTargets
@@ -2434,95 +2552,95 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public enum SpellUseType
     {
-        
+
         /// <remarks/>
         Unusable,
-        
+
         /// <remarks/>
         Prompt,
-        
+
         /// <remarks/>
         Target,
-        
+
         /// <remarks/>
         FourDigit,
-        
+
         /// <remarks/>
         ThreeDigit,
-        
+
         /// <remarks/>
         NoTarget,
-        
+
         /// <remarks/>
         TwoDigit,
-        
+
         /// <remarks/>
         Onedigit,
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public enum IntentDirection
     {
-        
+
         /// <remarks/>
         Front,
-        
+
         /// <remarks/>
         Back,
-        
+
         /// <remarks/>
         Left,
-        
+
         /// <remarks/>
         Right,
-        
+
         /// <remarks/>
         Nearby,
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public enum IntentTarget
     {
-        
+
         /// <remarks/>
         Hostile,
-        
+
         /// <remarks/>
         Friendly,
-        
+
         /// <remarks/>
         Pvp,
-        
+
         /// <remarks/>
         Group,
     }
-    
+
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(CastCost))]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class ClassCastCost
     {
-        
+
         private List<ItemSpecification> _items;
-        
+
         private ClassCastCostStat _stat;
-        
+
         private uint _gold;
-        
-        [System.Xml.Serialization.XmlArrayItemAttribute("Item", IsNullable=false)]
+
+        [System.Xml.Serialization.XmlArrayItemAttribute("Item", IsNullable = false)]
         public List<ItemSpecification> Items
         {
             get
@@ -2534,7 +2652,7 @@ namespace Hybrasyl.Castables
                 this._items = value;
             }
         }
-        
+
         public ClassCastCostStat Stat
         {
             get
@@ -2546,7 +2664,7 @@ namespace Hybrasyl.Castables
                 this._stat = value;
             }
         }
-        
+
         public uint Gold
         {
             get
@@ -2559,25 +2677,25 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class ClassCastCostStat
     {
-        
+
         private string _hp;
-        
+
         private string _mp;
-        
+
         public ClassCastCostStat()
         {
             this._hp = "0";
             this._mp = "0";
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute("0")]
         public string Hp
@@ -2591,7 +2709,7 @@ namespace Hybrasyl.Castables
                 this._hp = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute("0")]
         public string Mp
@@ -2606,22 +2724,22 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class CastCost : ClassCastCost
     {
-        
+
         private List<Class> _class;
-        
+
         public CastCost()
         {
             this._class = new List<Class>();
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<Class> Class
         {
@@ -2635,22 +2753,22 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class CastCostList
     {
-        
+
         private CastCost _castCost;
-        
+
         public CastCostList()
         {
             this._castCost = new CastCost();
         }
-        
+
         public CastCost CastCost
         {
             get
@@ -2663,24 +2781,24 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Category
     {
-        
+
         private bool _unique;
-        
+
         private string _value;
-        
+
         public Category()
         {
             this._unique = false;
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(false)]
         public bool Unique
@@ -2694,7 +2812,7 @@ namespace Hybrasyl.Castables
                 this._unique = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlTextAttribute()]
         public string Value
         {
@@ -2708,22 +2826,22 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Categories
     {
-        
+
         private Category _category;
-        
+
         public Categories()
         {
             this._category = new Category();
         }
-        
+
         public Category Category
         {
             get
@@ -2736,28 +2854,28 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public enum Book
     {
-        
+
         /// <remarks/>
         PrimarySkill,
-        
+
         /// <remarks/>
         SecondarySkill,
-        
+
         /// <remarks/>
         UtilitySkill,
-        
+
         /// <remarks/>
         PrimarySpell,
-        
+
         /// <remarks/>
         SecondarySpell,
-        
+
         /// <remarks/>
         UtilitySpell,
     }

--- a/HybrasylIntegration/HybrasylXML/XSD/Castables.Designer.cs
+++ b/HybrasylIntegration/HybrasylXML/XSD/Castables.Designer.cs
@@ -15,53 +15,53 @@ namespace Hybrasyl.Castables
     using System.ComponentModel;
     using System.Xml;
     using System.Collections.Generic;
-    
-    
+
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
-    [System.Xml.Serialization.XmlRootAttribute(Namespace="http://www.hybrasyl.com/XML/Actions", IsNullable=false)]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlRootAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions", IsNullable = false)]
     public partial class Castable
     {
-        
+
         private List<Description> _descriptions;
-        
+
         private string _name;
-        
+
         private Categories _categories;
-        
+
         private CastCostList _castCosts;
-        
+
         private List<Intent> _intents;
-        
+
         private MaxLevel _maxLevel;
-        
+
         private List<Requirement> _requirements;
-        
+
         private Restrictions _restrictions;
-        
+
         private Effects _effects;
-        
+
         private string _script;
-        
+
         private string _type;
-        
+
         private byte _icon;
-        
+
         private Book _book;
-        
+
         private List<Element> _element;
-        
+
         private byte _lines;
-        
+
         private List<Class> _class;
-        
+
         private int _cooldown;
-        
+
         private bool _isAssail;
-        
+
         public Castable()
         {
             this._class = new List<Class>();
@@ -78,8 +78,8 @@ namespace Hybrasyl.Castables
             this._cooldown = 0;
             this._isAssail = false;
         }
-        
-        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
+
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable = false)]
         public List<Description> Descriptions
         {
             get
@@ -91,7 +91,7 @@ namespace Hybrasyl.Castables
                 this._descriptions = value;
             }
         }
-        
+
         public string Name
         {
             get
@@ -103,7 +103,7 @@ namespace Hybrasyl.Castables
                 this._name = value;
             }
         }
-        
+
         public Categories Categories
         {
             get
@@ -115,7 +115,7 @@ namespace Hybrasyl.Castables
                 this._categories = value;
             }
         }
-        
+
         public CastCostList CastCosts
         {
             get
@@ -127,8 +127,8 @@ namespace Hybrasyl.Castables
                 this._castCosts = value;
             }
         }
-        
-        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
+
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable = false)]
         public List<Intent> Intents
         {
             get
@@ -140,7 +140,7 @@ namespace Hybrasyl.Castables
                 this._intents = value;
             }
         }
-        
+
         public MaxLevel MaxLevel
         {
             get
@@ -152,8 +152,8 @@ namespace Hybrasyl.Castables
                 this._maxLevel = value;
             }
         }
-        
-        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
+
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable = false)]
         public List<Requirement> Requirements
         {
             get
@@ -165,7 +165,7 @@ namespace Hybrasyl.Castables
                 this._requirements = value;
             }
         }
-        
+
         public Restrictions Restrictions
         {
             get
@@ -177,7 +177,7 @@ namespace Hybrasyl.Castables
                 this._restrictions = value;
             }
         }
-        
+
         public Effects Effects
         {
             get
@@ -189,7 +189,7 @@ namespace Hybrasyl.Castables
                 this._effects = value;
             }
         }
-        
+
         public string Script
         {
             get
@@ -201,7 +201,7 @@ namespace Hybrasyl.Castables
                 this._script = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public string Type
         {
@@ -214,7 +214,7 @@ namespace Hybrasyl.Castables
                 this._type = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Icon
         {
@@ -227,7 +227,7 @@ namespace Hybrasyl.Castables
                 this._icon = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public Book Book
         {
@@ -240,7 +240,7 @@ namespace Hybrasyl.Castables
                 this._book = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<Element> Element
         {
@@ -253,7 +253,7 @@ namespace Hybrasyl.Castables
                 this._element = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Lines
@@ -267,7 +267,7 @@ namespace Hybrasyl.Castables
                 this._lines = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<Class> Class
         {
@@ -280,7 +280,7 @@ namespace Hybrasyl.Castables
                 this._class = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(0)]
         public int Cooldown
@@ -294,7 +294,7 @@ namespace Hybrasyl.Castables
                 this._cooldown = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(false)]
         public bool IsAssail
@@ -309,24 +309,24 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Description
     {
-        
+
         private List<Class> _class;
-        
+
         private string _value;
-        
+
         public Description()
         {
             this._class = new List<Class>();
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<Class> Class
         {
@@ -339,7 +339,7 @@ namespace Hybrasyl.Castables
                 this._class = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlTextAttribute()]
         public string Value
         {
@@ -353,44 +353,44 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/HybrasylCommon")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/HybrasylCommon")]
     public enum Class
     {
-        
+
         /// <remarks/>
         Peasant,
-        
+
         /// <remarks/>
         Warrior,
-        
+
         /// <remarks/>
         Rogue,
-        
+
         /// <remarks/>
         Wizard,
-        
+
         /// <remarks/>
         Priest,
-        
+
         /// <remarks/>
         Monk,
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class RemoveStatus
     {
-        
+
         private ushort _icon;
-        
+
         private string _name;
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public ushort Icon
         {
@@ -403,7 +403,7 @@ namespace Hybrasyl.Castables
                 this._icon = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public string Name
         {
@@ -417,19 +417,19 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Conditions
     {
-        
+
         private ConditionList _add;
-        
+
         private ConditionList _remove;
-        
+
         public ConditionList Add
         {
             get
@@ -441,7 +441,7 @@ namespace Hybrasyl.Castables
                 this._add = value;
             }
         }
-        
+
         public ConditionList Remove
         {
             get
@@ -454,85 +454,85 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.FlagsAttribute()]
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.hybrasyl.com/XML/HybrasylCommon")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/HybrasylCommon")]
     public enum ConditionList
     {
-        
+
         /// <remarks/>
         Freeze = 1,
-        
+
         /// <remarks/>
         Sleep = 2,
-        
+
         /// <remarks/>
         Paralyze = 4,
-        
+
         /// <remarks/>
         Blind = 8,
-        
+
         /// <remarks/>
         Coma = 16,
-        
+
         /// <remarks/>
         Poison = 32,
-        
+
         /// <remarks/>
         Mist = 64,
-        
+
         /// <remarks/>
         Regen = 128,
-        
+
         /// <remarks/>
         Sight = 256,
-        
+
         /// <remarks/>
         Invisible = 512,
-        
+
         /// <remarks/>
         Mute = 1024,
-        
+
         /// <remarks/>
         ReflectPhysical = 2048,
-        
+
         /// <remarks/>
         ReflectMagical = 4096,
-        
+
         /// <remarks/>
         Invulnerable = 8192,
-        
+
         /// <remarks/>
         Charm = 16384,
-        
+
         /// <remarks/>
         IncreaseDamage = 32768,
-        
+
         /// <remarks/>
         ReduceDamage = 65536,
-        
+
         /// <remarks/>
         ProhibitUsage = 131072,
-        
+
         /// <remarks/>
         AbsorbSpell = 262144,
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class StatusStatEffects
     {
-        
+
         private List<StatEffect> _onCast;
-        
+
         private List<StatEffect> _onTick;
-        
-        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
+
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable = false)]
         public List<StatEffect> OnCast
         {
             get
@@ -544,8 +544,8 @@ namespace Hybrasyl.Castables
                 this._onCast = value;
             }
         }
-        
-        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
+
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable = false)]
         public List<StatEffect> OnTick
         {
             get
@@ -558,49 +558,49 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class StatEffect
     {
-        
+
         private sbyte _str;
-        
+
         private sbyte _int;
-        
+
         private sbyte _wis;
-        
+
         private sbyte _con;
-        
+
         private sbyte _dex;
-        
+
         private int _hp;
-        
+
         private int _mp;
-        
+
         private sbyte _hit;
-        
+
         private sbyte _dmg;
-        
+
         private sbyte _ac;
-        
+
         private sbyte _regen;
-        
+
         private sbyte _mr;
-        
+
         private Element _offensiveElement;
-        
+
         private Element _defensiveElement;
-        
+
         private float _damageModifier;
-        
+
         private float _healModifier;
-        
+
         private DamageType _damageType;
-        
+
         public StatEffect()
         {
             this._str = ((sbyte)(0));
@@ -616,7 +616,7 @@ namespace Hybrasyl.Castables
             this._regen = ((sbyte)(0));
             this._mr = ((sbyte)(0));
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Str
@@ -630,7 +630,7 @@ namespace Hybrasyl.Castables
                 this._str = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Int
@@ -644,7 +644,7 @@ namespace Hybrasyl.Castables
                 this._int = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Wis
@@ -658,7 +658,7 @@ namespace Hybrasyl.Castables
                 this._wis = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Con
@@ -672,7 +672,7 @@ namespace Hybrasyl.Castables
                 this._con = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Dex
@@ -686,7 +686,7 @@ namespace Hybrasyl.Castables
                 this._dex = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(0)]
         public int Hp
@@ -700,7 +700,7 @@ namespace Hybrasyl.Castables
                 this._hp = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(0)]
         public int Mp
@@ -714,7 +714,7 @@ namespace Hybrasyl.Castables
                 this._mp = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Hit
@@ -728,7 +728,7 @@ namespace Hybrasyl.Castables
                 this._hit = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Dmg
@@ -742,7 +742,7 @@ namespace Hybrasyl.Castables
                 this._dmg = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Ac
@@ -756,7 +756,7 @@ namespace Hybrasyl.Castables
                 this._ac = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Regen
@@ -770,7 +770,7 @@ namespace Hybrasyl.Castables
                 this._regen = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Mr
@@ -784,7 +784,7 @@ namespace Hybrasyl.Castables
                 this._mr = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public Element OffensiveElement
         {
@@ -797,7 +797,7 @@ namespace Hybrasyl.Castables
                 this._offensiveElement = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public Element DefensiveElement
         {
@@ -810,7 +810,7 @@ namespace Hybrasyl.Castables
                 this._defensiveElement = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public float DamageModifier
         {
@@ -823,7 +823,7 @@ namespace Hybrasyl.Castables
                 this._damageModifier = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public float HealModifier
         {
@@ -836,7 +836,7 @@ namespace Hybrasyl.Castables
                 this._healModifier = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public DamageType DamageType
         {
@@ -850,84 +850,84 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public enum Element
     {
-        
+
         /// <remarks/>
         None,
-        
+
         /// <remarks/>
         Fire,
-        
+
         /// <remarks/>
         Water,
-        
+
         /// <remarks/>
         Wind,
-        
+
         /// <remarks/>
         Earth,
-        
+
         /// <remarks/>
         Light,
-        
+
         /// <remarks/>
         Dark,
-        
+
         /// <remarks/>
         Wood,
-        
+
         /// <remarks/>
         Metal,
-        
+
         /// <remarks/>
         Undead,
-        
+
         /// <remarks/>
         Random,
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/HybrasylCommon")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/HybrasylCommon")]
     public enum DamageType
     {
-        
+
         /// <remarks/>
         Direct,
-        
+
         /// <remarks/>
         Physical,
-        
+
         /// <remarks/>
         Magical,
-        
+
         /// <remarks/>
         Elemental,
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class AddStatus
     {
-        
+
         private List<StatusStatEffects> _statEffects;
-        
+
         private Conditions _conditions;
-        
+
         private ushort _icon;
-        
+
         private int _duration;
-        
+
         private int _tick;
-        
+
         [System.Xml.Serialization.XmlElementAttribute("StatEffects")]
         public List<StatusStatEffects> StatEffects
         {
@@ -940,7 +940,7 @@ namespace Hybrasyl.Castables
                 this._statEffects = value;
             }
         }
-        
+
         public Conditions Conditions
         {
             get
@@ -952,7 +952,7 @@ namespace Hybrasyl.Castables
                 this._conditions = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public ushort Icon
         {
@@ -965,7 +965,7 @@ namespace Hybrasyl.Castables
                 this._icon = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public int Duration
         {
@@ -978,7 +978,7 @@ namespace Hybrasyl.Castables
                 this._duration = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public int Tick
         {
@@ -992,19 +992,19 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Statuses
     {
-        
+
         private List<AddStatus> _add;
-        
+
         private List<RemoveStatus> _remove;
-        
+
         [System.Xml.Serialization.XmlElementAttribute("Add")]
         public List<AddStatus> Add
         {
@@ -1017,7 +1017,7 @@ namespace Hybrasyl.Castables
                 this._add = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlElementAttribute("Remove")]
         public List<RemoveStatus> Remove
         {
@@ -1031,32 +1031,32 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Damage
     {
-        
+
         private DamageFlags _flags;
-        
+
         private SimpleQuantity _simple;
-        
+
         private string _formula;
-        
+
         private bool _timeBased;
-        
+
         private uint _duration;
-        
+
         private DamageType _type;
-        
+
         public Damage()
         {
             this._simple = new SimpleQuantity();
         }
-        
+
         public DamageFlags Flags
         {
             get
@@ -1068,7 +1068,7 @@ namespace Hybrasyl.Castables
                 this._flags = value;
             }
         }
-        
+
         public SimpleQuantity Simple
         {
             get
@@ -1080,7 +1080,7 @@ namespace Hybrasyl.Castables
                 this._simple = value;
             }
         }
-        
+
         public string Formula
         {
             get
@@ -1092,7 +1092,7 @@ namespace Hybrasyl.Castables
                 this._formula = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public bool TimeBased
         {
@@ -1105,7 +1105,7 @@ namespace Hybrasyl.Castables
                 this._timeBased = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public uint Duration
         {
@@ -1118,7 +1118,7 @@ namespace Hybrasyl.Castables
                 this._duration = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public DamageType Type
         {
@@ -1132,43 +1132,43 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.FlagsAttribute()]
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public enum DamageFlags
     {
-        
+
         /// <remarks/>
         Scaled = 1,
-        
+
         /// <remarks/>
         Resistance = 2,
-        
+
         /// <remarks/>
         Threat = 4,
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class SimpleQuantity
     {
-        
+
         private string _min;
-        
+
         private string _max;
-        
+
         public SimpleQuantity()
         {
             this._min = "0";
             this._max = "0";
         }
-        
-        [System.Xml.Serialization.XmlAttributeAttribute(DataType="nonNegativeInteger")]
+
+        [System.Xml.Serialization.XmlAttributeAttribute(DataType = "nonNegativeInteger")]
         [System.ComponentModel.DefaultValueAttribute("0")]
         public string Min
         {
@@ -1181,8 +1181,8 @@ namespace Hybrasyl.Castables
                 this._min = value;
             }
         }
-        
-        [System.Xml.Serialization.XmlAttributeAttribute(DataType="nonNegativeInteger")]
+
+        [System.Xml.Serialization.XmlAttributeAttribute(DataType = "nonNegativeInteger")]
         [System.ComponentModel.DefaultValueAttribute("0")]
         public string Max
         {
@@ -1196,28 +1196,28 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Heal
     {
-        
+
         private SimpleQuantity _simple;
-        
+
         private string _formula;
-        
+
         private bool _timeBased;
-        
+
         private uint _duration;
-        
+
         public Heal()
         {
             this._simple = new SimpleQuantity();
         }
-        
+
         public SimpleQuantity Simple
         {
             get
@@ -1229,7 +1229,7 @@ namespace Hybrasyl.Castables
                 this._simple = value;
             }
         }
-        
+
         public string Formula
         {
             get
@@ -1241,7 +1241,7 @@ namespace Hybrasyl.Castables
                 this._formula = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public bool TimeBased
         {
@@ -1254,7 +1254,7 @@ namespace Hybrasyl.Castables
                 this._timeBased = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public uint Duration
         {
@@ -1268,26 +1268,26 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class AnimationDuration
     {
-        
+
         private ushort _id;
-        
+
         private ushort _speed;
-        
+
         private uint _tick;
-        
+
         public AnimationDuration()
         {
             this._speed = ((ushort)(100));
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public ushort Id
         {
@@ -1300,7 +1300,7 @@ namespace Hybrasyl.Castables
                 this._id = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(ushort), "100")]
         public ushort Speed
@@ -1314,7 +1314,7 @@ namespace Hybrasyl.Castables
                 this._speed = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public uint Tick
         {
@@ -1328,21 +1328,21 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class AnimationDurationGroup
     {
-        
+
         private AnimationDuration _player;
-        
+
         private AnimationDuration _spellEffect;
-        
+
         private AnimationDuration _target;
-        
+
         public AnimationDuration Player
         {
             get
@@ -1354,7 +1354,7 @@ namespace Hybrasyl.Castables
                 this._player = value;
             }
         }
-        
+
         public AnimationDuration SpellEffect
         {
             get
@@ -1366,7 +1366,7 @@ namespace Hybrasyl.Castables
                 this._spellEffect = value;
             }
         }
-        
+
         public AnimationDuration Target
         {
             get
@@ -1379,24 +1379,24 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Animation
     {
-        
+
         private ushort _id;
-        
+
         private ushort _speed;
-        
+
         public Animation()
         {
             this._speed = ((ushort)(100));
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public ushort Id
         {
@@ -1409,7 +1409,7 @@ namespace Hybrasyl.Castables
                 this._id = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(ushort), "100")]
         public ushort Speed
@@ -1424,26 +1424,26 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Motion
     {
-        
+
         private List<Class> _class;
-        
+
         private int _id;
-        
+
         private int _speed;
-        
+
         public Motion()
         {
             this._class = new List<Class>();
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<Class> Class
         {
@@ -1456,7 +1456,7 @@ namespace Hybrasyl.Castables
                 this._class = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public int Id
         {
@@ -1469,7 +1469,7 @@ namespace Hybrasyl.Castables
                 this._id = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public int Speed
         {
@@ -1483,22 +1483,22 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class AnimationGroup
     {
-        
+
         private List<Motion> _player;
-        
+
         private Animation _spellEffect;
-        
+
         private Animation _target;
-        
-        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
+
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable = false)]
         public List<Motion> Player
         {
             get
@@ -1510,7 +1510,7 @@ namespace Hybrasyl.Castables
                 this._player = value;
             }
         }
-        
+
         public Animation SpellEffect
         {
             get
@@ -1522,7 +1522,7 @@ namespace Hybrasyl.Castables
                 this._spellEffect = value;
             }
         }
-        
+
         public Animation Target
         {
             get
@@ -1535,21 +1535,21 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Animations
     {
-        
+
         private AnimationGroup _onCast;
-        
+
         private AnimationDurationGroup _onTick;
-        
+
         private AnimationDurationGroup _onEnd;
-        
+
         public AnimationGroup OnCast
         {
             get
@@ -1561,7 +1561,7 @@ namespace Hybrasyl.Castables
                 this._onCast = value;
             }
         }
-        
+
         public AnimationDurationGroup OnTick
         {
             get
@@ -1573,7 +1573,7 @@ namespace Hybrasyl.Castables
                 this._onTick = value;
             }
         }
-        
+
         public AnimationDurationGroup OnEnd
         {
             get
@@ -1586,35 +1586,35 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Effects
     {
-        
+
         private Animations _animations;
-        
+
         private EffectsSound _sound;
-        
+
         private Heal _heal;
-        
+
         private Damage _damage;
-        
+
         private List<StatEffect> _statEffects;
-        
+
         private Statuses _statuses;
-        
+
         private bool _scriptOverride;
-        
+
         public Effects()
         {
             this._statuses = new Statuses();
             this._scriptOverride = false;
         }
-        
+
         public Animations Animations
         {
             get
@@ -1626,7 +1626,7 @@ namespace Hybrasyl.Castables
                 this._animations = value;
             }
         }
-        
+
         public EffectsSound Sound
         {
             get
@@ -1638,7 +1638,7 @@ namespace Hybrasyl.Castables
                 this._sound = value;
             }
         }
-        
+
         public Heal Heal
         {
             get
@@ -1650,7 +1650,7 @@ namespace Hybrasyl.Castables
                 this._heal = value;
             }
         }
-        
+
         public Damage Damage
         {
             get
@@ -1662,8 +1662,8 @@ namespace Hybrasyl.Castables
                 this._damage = value;
             }
         }
-        
-        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
+
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable = false)]
         public List<StatEffect> StatEffects
         {
             get
@@ -1675,7 +1675,7 @@ namespace Hybrasyl.Castables
                 this._statEffects = value;
             }
         }
-        
+
         public Statuses Statuses
         {
             get
@@ -1687,7 +1687,7 @@ namespace Hybrasyl.Castables
                 this._statuses = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(false)]
         public bool ScriptOverride
@@ -1702,17 +1702,17 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class EffectsSound
     {
-        
+
         private byte _id;
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Id
         {
@@ -1726,25 +1726,25 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Restrictions
     {
-        
+
         private List<WeaponType> _weaponType;
-        
+
         private List<EquipmentSlot> _equipType;
-        
+
         public Restrictions()
         {
             this._equipType = new List<EquipmentSlot>();
             this._weaponType = new List<WeaponType>();
         }
-        
+
         [System.Xml.Serialization.XmlElementAttribute("WeaponType")]
         public List<WeaponType> WeaponType
         {
@@ -1757,7 +1757,7 @@ namespace Hybrasyl.Castables
                 this._weaponType = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlElementAttribute("EquipType")]
         public List<EquipmentSlot> EquipType
         {
@@ -1771,116 +1771,116 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/HybrasylCommon")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/HybrasylCommon")]
     public enum WeaponType
     {
-        
+
         /// <remarks/>
         OneHand,
-        
+
         /// <remarks/>
         TwoHand,
-        
+
         /// <remarks/>
         Dagger,
-        
+
         /// <remarks/>
         Staff,
-        
+
         /// <remarks/>
         Claw,
-        
+
         /// <remarks/>
         None,
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/HybrasylCommon")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/HybrasylCommon")]
     public enum EquipmentSlot
     {
-        
+
         /// <remarks/>
         None,
-        
+
         /// <remarks/>
         Weapon,
-        
+
         /// <remarks/>
         Armor,
-        
+
         /// <remarks/>
         Shield,
-        
+
         /// <remarks/>
         Helmet,
-        
+
         /// <remarks/>
         Earring,
-        
+
         /// <remarks/>
         Necklace,
-        
+
         /// <remarks/>
         LeftHand,
-        
+
         /// <remarks/>
         RightHand,
-        
+
         /// <remarks/>
         LeftArm,
-        
+
         /// <remarks/>
         RightArm,
-        
+
         /// <remarks/>
         Waist,
-        
+
         /// <remarks/>
         Leg,
-        
+
         /// <remarks/>
         Foot,
-        
+
         /// <remarks/>
         FirstAcc,
-        
+
         /// <remarks/>
         Trousers,
-        
+
         /// <remarks/>
         Coat,
-        
+
         /// <remarks/>
         SecondAcc,
-        
+
         /// <remarks/>
         ThirdAcc,
-        
+
         /// <remarks/>
         Gauntlet,
-        
+
         /// <remarks/>
         Ring,
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class LearnPrerequisite
     {
-        
+
         private byte _level;
-        
+
         private byte _ab;
-        
+
         private string _value;
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Level
         {
@@ -1893,7 +1893,7 @@ namespace Hybrasyl.Castables
                 this._level = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Ab
         {
@@ -1906,7 +1906,7 @@ namespace Hybrasyl.Castables
                 this._ab = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlTextAttribute()]
         public string Value
         {
@@ -1920,33 +1920,33 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(Requirement))]
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class ClassRequirement
     {
-        
+
         private ClassRequirementLevel _level;
-        
+
         private ClassRequirementAB _ab;
-        
+
         private List<ItemSpecification> _items;
-        
+
         private uint _gold;
-        
+
         private ClassRequirementPhysical _physical;
-        
+
         private List<LearnPrerequisite> _prerequisites;
-        
+
         public ClassRequirement()
         {
             this._prerequisites = new List<LearnPrerequisite>();
         }
-        
+
         public ClassRequirementLevel Level
         {
             get
@@ -1958,7 +1958,7 @@ namespace Hybrasyl.Castables
                 this._level = value;
             }
         }
-        
+
         public ClassRequirementAB Ab
         {
             get
@@ -1970,8 +1970,8 @@ namespace Hybrasyl.Castables
                 this._ab = value;
             }
         }
-        
-        [System.Xml.Serialization.XmlArrayItemAttribute("Item", IsNullable=false)]
+
+        [System.Xml.Serialization.XmlArrayItemAttribute("Item", IsNullable = false)]
         public List<ItemSpecification> Items
         {
             get
@@ -1983,7 +1983,7 @@ namespace Hybrasyl.Castables
                 this._items = value;
             }
         }
-        
+
         public uint Gold
         {
             get
@@ -1995,7 +1995,7 @@ namespace Hybrasyl.Castables
                 this._gold = value;
             }
         }
-        
+
         public ClassRequirementPhysical Physical
         {
             get
@@ -2007,8 +2007,8 @@ namespace Hybrasyl.Castables
                 this._physical = value;
             }
         }
-        
-        [System.Xml.Serialization.XmlArrayItemAttribute("Prerequisite", IsNullable=false)]
+
+        [System.Xml.Serialization.XmlArrayItemAttribute("Prerequisite", IsNullable = false)]
         public List<LearnPrerequisite> Prerequisites
         {
             get
@@ -2021,25 +2021,25 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class ClassRequirementLevel
     {
-        
+
         private byte _min;
-        
+
         private byte _max;
-        
+
         public ClassRequirementLevel()
         {
             this._min = ((byte)(0));
             this._max = ((byte)(255));
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Min
@@ -2053,7 +2053,7 @@ namespace Hybrasyl.Castables
                 this._min = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "255")]
         public byte Max
@@ -2068,25 +2068,25 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class ClassRequirementAB
     {
-        
+
         private byte _min;
-        
+
         private byte _max;
-        
+
         public ClassRequirementAB()
         {
             this._min = ((byte)(0));
             this._max = ((byte)(255));
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Min
@@ -2100,7 +2100,7 @@ namespace Hybrasyl.Castables
                 this._min = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "255")]
         public byte Max
@@ -2115,24 +2115,24 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class ItemSpecification
     {
-        
+
         private byte _quantity;
-        
+
         private string _value;
-        
+
         public ItemSpecification()
         {
             this._quantity = ((byte)(1));
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "1")]
         public byte Quantity
@@ -2146,7 +2146,7 @@ namespace Hybrasyl.Castables
                 this._quantity = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlTextAttribute()]
         public string Value
         {
@@ -2160,29 +2160,29 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class ClassRequirementPhysical
     {
-        
+
         private byte _str;
-        
+
         private byte _int;
-        
+
         private byte _wis;
-        
+
         private byte _con;
-        
+
         private byte _dex;
-        
+
         private uint _hp;
-        
+
         private uint _mp;
-        
+
         public ClassRequirementPhysical()
         {
             this._str = ((byte)(0));
@@ -2193,7 +2193,7 @@ namespace Hybrasyl.Castables
             this._hp = ((uint)(0));
             this._mp = ((uint)(0));
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Str
@@ -2207,7 +2207,7 @@ namespace Hybrasyl.Castables
                 this._str = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Int
@@ -2221,7 +2221,7 @@ namespace Hybrasyl.Castables
                 this._int = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Wis
@@ -2235,7 +2235,7 @@ namespace Hybrasyl.Castables
                 this._wis = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Con
@@ -2249,7 +2249,7 @@ namespace Hybrasyl.Castables
                 this._con = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Dex
@@ -2263,7 +2263,7 @@ namespace Hybrasyl.Castables
                 this._dex = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(uint), "0")]
         public uint Hp
@@ -2277,7 +2277,7 @@ namespace Hybrasyl.Castables
                 this._hp = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(uint), "0")]
         public uint Mp
@@ -2292,22 +2292,22 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Requirement : ClassRequirement
     {
-        
+
         private List<Class> _class;
-        
+
         public Requirement()
         {
             this._class = new List<Class>();
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<Class> Class
         {
@@ -2321,27 +2321,27 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class MaxLevel
     {
-        
+
         private byte _monk;
-        
+
         private byte _warrior;
-        
+
         private byte _peasant;
-        
+
         private byte _wizard;
-        
+
         private byte _priest;
-        
+
         private byte _rogue;
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Monk
         {
@@ -2354,7 +2354,7 @@ namespace Hybrasyl.Castables
                 this._monk = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Warrior
         {
@@ -2367,7 +2367,7 @@ namespace Hybrasyl.Castables
                 this._warrior = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Peasant
         {
@@ -2380,7 +2380,7 @@ namespace Hybrasyl.Castables
                 this._peasant = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Wizard
         {
@@ -2393,7 +2393,7 @@ namespace Hybrasyl.Castables
                 this._wizard = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Priest
         {
@@ -2406,7 +2406,7 @@ namespace Hybrasyl.Castables
                 this._priest = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Rogue
         {
@@ -2420,25 +2420,25 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Intent
     {
-        
+
         private SpellUseType _useType;
-        
+
         private byte _radius;
-        
+
         private IntentDirection _direction;
-        
+
         private List<IntentTarget> _target;
-        
+
         private byte _maxTargets;
-        
+
         public Intent()
         {
             this._target = new List<IntentTarget>();
@@ -2447,7 +2447,7 @@ namespace Hybrasyl.Castables
             this._direction = IntentDirection.Front;
             this._maxTargets = ((byte)(0));
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(SpellUseType.NoTarget)]
         public SpellUseType UseType
@@ -2461,7 +2461,7 @@ namespace Hybrasyl.Castables
                 this._useType = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Radius
@@ -2475,7 +2475,7 @@ namespace Hybrasyl.Castables
                 this._radius = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(IntentDirection.Front)]
         public IntentDirection Direction
@@ -2489,7 +2489,7 @@ namespace Hybrasyl.Castables
                 this._direction = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<IntentTarget> Target
         {
@@ -2502,7 +2502,7 @@ namespace Hybrasyl.Castables
                 this._target = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte MaxTargets
@@ -2517,95 +2517,95 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public enum SpellUseType
     {
-        
+
         /// <remarks/>
         Unusable,
-        
+
         /// <remarks/>
         Prompt,
-        
+
         /// <remarks/>
         Target,
-        
+
         /// <remarks/>
         FourDigit,
-        
+
         /// <remarks/>
         ThreeDigit,
-        
+
         /// <remarks/>
         NoTarget,
-        
+
         /// <remarks/>
         TwoDigit,
-        
+
         /// <remarks/>
         Onedigit,
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public enum IntentDirection
     {
-        
+
         /// <remarks/>
         Front,
-        
+
         /// <remarks/>
         Back,
-        
+
         /// <remarks/>
         Left,
-        
+
         /// <remarks/>
         Right,
-        
+
         /// <remarks/>
         Nearby,
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public enum IntentTarget
     {
-        
+
         /// <remarks/>
         Hostile,
-        
+
         /// <remarks/>
         Friendly,
-        
+
         /// <remarks/>
         Pvp,
-        
+
         /// <remarks/>
         Group,
     }
-    
+
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(CastCost))]
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class ClassCastCost
     {
-        
+
         private List<ItemSpecification> _items;
-        
+
         private ClassCastCostStat _stat;
-        
+
         private uint _gold;
-        
-        [System.Xml.Serialization.XmlArrayItemAttribute("Item", IsNullable=false)]
+
+        [System.Xml.Serialization.XmlArrayItemAttribute("Item", IsNullable = false)]
         public List<ItemSpecification> Items
         {
             get
@@ -2617,7 +2617,7 @@ namespace Hybrasyl.Castables
                 this._items = value;
             }
         }
-        
+
         public ClassCastCostStat Stat
         {
             get
@@ -2629,7 +2629,7 @@ namespace Hybrasyl.Castables
                 this._stat = value;
             }
         }
-        
+
         public uint Gold
         {
             get
@@ -2642,25 +2642,25 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class ClassCastCostStat
     {
-        
+
         private string _hp;
-        
+
         private string _mp;
-        
+
         public ClassCastCostStat()
         {
             this._hp = "0";
             this._mp = "0";
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute("0")]
         public string Hp
@@ -2674,7 +2674,7 @@ namespace Hybrasyl.Castables
                 this._hp = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute("0")]
         public string Mp
@@ -2689,22 +2689,22 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class CastCost : ClassCastCost
     {
-        
+
         private List<Class> _class;
-        
+
         public CastCost()
         {
             this._class = new List<Class>();
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<Class> Class
         {
@@ -2718,22 +2718,22 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class CastCostList
     {
-        
+
         private CastCost _castCost;
-        
+
         public CastCostList()
         {
             this._castCost = new CastCost();
         }
-        
+
         public CastCost CastCost
         {
             get
@@ -2746,24 +2746,24 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Category
     {
-        
+
         private bool _unique;
-        
+
         private string _value;
-        
+
         public Category()
         {
             this._unique = false;
         }
-        
+
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(false)]
         public bool Unique
@@ -2777,7 +2777,7 @@ namespace Hybrasyl.Castables
                 this._unique = value;
             }
         }
-        
+
         [System.Xml.Serialization.XmlTextAttribute()]
         public string Value
         {
@@ -2791,22 +2791,22 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public partial class Categories
     {
-        
+
         private Category _category;
-        
+
         public Categories()
         {
             this._category = new Category();
         }
-        
+
         public Category Category
         {
             get
@@ -2819,28 +2819,28 @@ namespace Hybrasyl.Castables
             }
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
     public enum Book
     {
-        
+
         /// <remarks/>
         PrimarySkill,
-        
+
         /// <remarks/>
         SecondarySkill,
-        
+
         /// <remarks/>
         UtilitySkill,
-        
+
         /// <remarks/>
         PrimarySpell,
-        
+
         /// <remarks/>
         SecondarySpell,
-        
+
         /// <remarks/>
         UtilitySpell,
     }

--- a/HybrasylIntegration/HybrasylXML/XSD/Castables.Designer.cs
+++ b/HybrasylIntegration/HybrasylXML/XSD/Castables.Designer.cs
@@ -15,53 +15,53 @@ namespace Hybrasyl.Castables
     using System.ComponentModel;
     using System.Xml;
     using System.Collections.Generic;
-
-
+    
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
-    [System.Xml.Serialization.XmlRootAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions", IsNullable = false)]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlRootAttribute(Namespace="http://www.hybrasyl.com/XML/Actions", IsNullable=false)]
     public partial class Castable
     {
-
+        
         private List<Description> _descriptions;
-
+        
         private string _name;
-
+        
         private Categories _categories;
-
+        
         private CastCostList _castCosts;
-
+        
         private List<Intent> _intents;
-
+        
         private MaxLevel _maxLevel;
-
+        
         private List<Requirement> _requirements;
-
+        
         private Restrictions _restrictions;
-
+        
         private Effects _effects;
-
+        
         private string _script;
-
+        
         private string _type;
-
+        
         private byte _icon;
-
+        
         private Book _book;
-
+        
         private List<Element> _element;
-
+        
         private byte _lines;
-
+        
         private List<Class> _class;
-
+        
         private int _cooldown;
-
+        
         private bool _isAssail;
-
+        
         public Castable()
         {
             this._class = new List<Class>();
@@ -78,8 +78,8 @@ namespace Hybrasyl.Castables
             this._cooldown = 0;
             this._isAssail = false;
         }
-
-        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable = false)]
+        
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
         public List<Description> Descriptions
         {
             get
@@ -91,7 +91,7 @@ namespace Hybrasyl.Castables
                 this._descriptions = value;
             }
         }
-
+        
         public string Name
         {
             get
@@ -103,7 +103,7 @@ namespace Hybrasyl.Castables
                 this._name = value;
             }
         }
-
+        
         public Categories Categories
         {
             get
@@ -115,7 +115,7 @@ namespace Hybrasyl.Castables
                 this._categories = value;
             }
         }
-
+        
         public CastCostList CastCosts
         {
             get
@@ -127,8 +127,8 @@ namespace Hybrasyl.Castables
                 this._castCosts = value;
             }
         }
-
-        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable = false)]
+        
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
         public List<Intent> Intents
         {
             get
@@ -140,7 +140,7 @@ namespace Hybrasyl.Castables
                 this._intents = value;
             }
         }
-
+        
         public MaxLevel MaxLevel
         {
             get
@@ -152,8 +152,8 @@ namespace Hybrasyl.Castables
                 this._maxLevel = value;
             }
         }
-
-        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable = false)]
+        
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
         public List<Requirement> Requirements
         {
             get
@@ -165,7 +165,7 @@ namespace Hybrasyl.Castables
                 this._requirements = value;
             }
         }
-
+        
         public Restrictions Restrictions
         {
             get
@@ -177,7 +177,7 @@ namespace Hybrasyl.Castables
                 this._restrictions = value;
             }
         }
-
+        
         public Effects Effects
         {
             get
@@ -189,7 +189,7 @@ namespace Hybrasyl.Castables
                 this._effects = value;
             }
         }
-
+        
         public string Script
         {
             get
@@ -201,7 +201,7 @@ namespace Hybrasyl.Castables
                 this._script = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public string Type
         {
@@ -214,7 +214,7 @@ namespace Hybrasyl.Castables
                 this._type = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Icon
         {
@@ -227,7 +227,7 @@ namespace Hybrasyl.Castables
                 this._icon = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public Book Book
         {
@@ -240,7 +240,7 @@ namespace Hybrasyl.Castables
                 this._book = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<Element> Element
         {
@@ -253,7 +253,7 @@ namespace Hybrasyl.Castables
                 this._element = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Lines
@@ -267,7 +267,7 @@ namespace Hybrasyl.Castables
                 this._lines = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<Class> Class
         {
@@ -280,7 +280,7 @@ namespace Hybrasyl.Castables
                 this._class = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(0)]
         public int Cooldown
@@ -294,7 +294,7 @@ namespace Hybrasyl.Castables
                 this._cooldown = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(false)]
         public bool IsAssail
@@ -309,24 +309,24 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class Description
     {
-
+        
         private List<Class> _class;
-
+        
         private string _value;
-
+        
         public Description()
         {
             this._class = new List<Class>();
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<Class> Class
         {
@@ -339,7 +339,7 @@ namespace Hybrasyl.Castables
                 this._class = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlTextAttribute()]
         public string Value
         {
@@ -353,44 +353,44 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/HybrasylCommon")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/HybrasylCommon")]
     public enum Class
     {
-
+        
         /// <remarks/>
         Peasant,
-
+        
         /// <remarks/>
         Warrior,
-
+        
         /// <remarks/>
         Rogue,
-
+        
         /// <remarks/>
         Wizard,
-
+        
         /// <remarks/>
         Priest,
-
+        
         /// <remarks/>
         Monk,
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class RemoveStatus
     {
-
+        
         private ushort _icon;
-
+        
         private string _name;
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public ushort Icon
         {
@@ -403,7 +403,7 @@ namespace Hybrasyl.Castables
                 this._icon = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public string Name
         {
@@ -417,19 +417,19 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class Conditions
     {
-
+        
         private ConditionList _add;
-
+        
         private ConditionList _remove;
-
+        
         public ConditionList Add
         {
             get
@@ -441,7 +441,7 @@ namespace Hybrasyl.Castables
                 this._add = value;
             }
         }
-
+        
         public ConditionList Remove
         {
             get
@@ -454,141 +454,99 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.FlagsAttribute()]
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/HybrasylCommon")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.hybrasyl.com/XML/HybrasylCommon")]
     public enum ConditionList
     {
-
+        
         /// <remarks/>
         Freeze = 1,
-
+        
         /// <remarks/>
         Sleep = 2,
-
+        
         /// <remarks/>
         Paralyze = 4,
-
+        
         /// <remarks/>
         Blind = 8,
-
+        
         /// <remarks/>
         Coma = 16,
-
+        
         /// <remarks/>
         Poison = 32,
-
+        
         /// <remarks/>
         Mist = 64,
-
+        
         /// <remarks/>
         Regen = 128,
-
+        
         /// <remarks/>
         Sight = 256,
-
+        
         /// <remarks/>
         Invisible = 512,
-
+        
         /// <remarks/>
         Mute = 1024,
-
+        
         /// <remarks/>
         ReflectPhysical = 2048,
-
+        
         /// <remarks/>
         ReflectMagical = 4096,
-
+        
         /// <remarks/>
         Invulnerable = 8192,
-
+        
         /// <remarks/>
         Charm = 16384,
-
+        
         /// <remarks/>
         IncreaseDamage = 32768,
-
+        
         /// <remarks/>
         ReduceDamage = 65536,
-
+        
         /// <remarks/>
         ProhibitUsage = 131072,
-
+        
         /// <remarks/>
         AbsorbSpell = 262144,
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
-    public partial class StatusAnimation
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    public partial class StatusStatEffects
     {
-
-        private ushort _targetEffect;
-
-        private ushort _casterEffect;
-
-        private string _message;
-
-        [System.Xml.Serialization.XmlAttributeAttribute()]
-        public ushort TargetEffect
+        
+        private List<StatEffect> _onCast;
+        
+        private List<StatEffect> _onTick;
+        
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
+        public List<StatEffect> OnCast
         {
             get
             {
-                return this._targetEffect;
+                return this._onCast;
             }
             set
             {
-                this._targetEffect = value;
+                this._onCast = value;
             }
         }
-
-        [System.Xml.Serialization.XmlAttributeAttribute()]
-        public ushort CasterEffect
-        {
-            get
-            {
-                return this._casterEffect;
-            }
-            set
-            {
-                this._casterEffect = value;
-            }
-        }
-
-        [System.Xml.Serialization.XmlAttributeAttribute()]
-        public string Message
-        {
-            get
-            {
-                return this._message;
-            }
-            set
-            {
-                this._message = value;
-            }
-        }
-    }
-
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
-    [System.SerializableAttribute()]
-    [System.Diagnostics.DebuggerStepThroughAttribute()]
-    [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
-    public partial class StatusAnimations
-    {
-
-        private StatusAnimation _onTick;
-
-        private StatusAnimation _onStart;
-
-        private StatusAnimation _onEnd;
-
-        public StatusAnimation OnTick
+        
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
+        public List<StatEffect> OnTick
         {
             get
             {
@@ -599,165 +557,50 @@ namespace Hybrasyl.Castables
                 this._onTick = value;
             }
         }
-
-        public StatusAnimation OnStart
-        {
-            get
-            {
-                return this._onStart;
-            }
-            set
-            {
-                this._onStart = value;
-            }
-        }
-
-        public StatusAnimation OnEnd
-        {
-            get
-            {
-                return this._onEnd;
-            }
-            set
-            {
-                this._onEnd = value;
-            }
-        }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
-    public partial class AddStatus
-    {
-
-        private List<StatEffect> _statEffect;
-
-        private StatusAnimations _animations;
-
-        private Conditions _conditions;
-
-        private ushort _icon;
-
-        private int _duration;
-
-        private int _tick;
-
-        [System.Xml.Serialization.XmlElementAttribute("StatEffect")]
-        public List<StatEffect> StatEffect
-        {
-            get
-            {
-                return this._statEffect;
-            }
-            set
-            {
-                this._statEffect = value;
-            }
-        }
-
-        public StatusAnimations Animations
-        {
-            get
-            {
-                return this._animations;
-            }
-            set
-            {
-                this._animations = value;
-            }
-        }
-
-        public Conditions Conditions
-        {
-            get
-            {
-                return this._conditions;
-            }
-            set
-            {
-                this._conditions = value;
-            }
-        }
-
-        [System.Xml.Serialization.XmlAttributeAttribute()]
-        public ushort Icon
-        {
-            get
-            {
-                return this._icon;
-            }
-            set
-            {
-                this._icon = value;
-            }
-        }
-
-        [System.Xml.Serialization.XmlAttributeAttribute()]
-        public int Duration
-        {
-            get
-            {
-                return this._duration;
-            }
-            set
-            {
-                this._duration = value;
-            }
-        }
-
-        [System.Xml.Serialization.XmlAttributeAttribute()]
-        public int Tick
-        {
-            get
-            {
-                return this._tick;
-            }
-            set
-            {
-                this._tick = value;
-            }
-        }
-    }
-
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
-    [System.SerializableAttribute()]
-    [System.Diagnostics.DebuggerStepThroughAttribute()]
-    [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class StatEffect
     {
-
+        
         private sbyte _str;
-
+        
         private sbyte _int;
-
+        
         private sbyte _wis;
-
+        
         private sbyte _con;
-
+        
         private sbyte _dex;
-
+        
         private int _hp;
-
+        
         private int _mp;
-
+        
         private sbyte _hit;
-
+        
         private sbyte _dmg;
-
+        
         private sbyte _ac;
-
+        
         private sbyte _regen;
-
+        
         private sbyte _mr;
-
+        
         private Element _offensiveElement;
-
+        
         private Element _defensiveElement;
-
+        
+        private float _damageModifier;
+        
+        private float _healModifier;
+        
+        private DamageType _damageType;
+        
         public StatEffect()
         {
             this._str = ((sbyte)(0));
@@ -773,7 +616,7 @@ namespace Hybrasyl.Castables
             this._regen = ((sbyte)(0));
             this._mr = ((sbyte)(0));
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Str
@@ -787,7 +630,7 @@ namespace Hybrasyl.Castables
                 this._str = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Int
@@ -801,7 +644,7 @@ namespace Hybrasyl.Castables
                 this._int = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Wis
@@ -815,7 +658,7 @@ namespace Hybrasyl.Castables
                 this._wis = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Con
@@ -829,7 +672,7 @@ namespace Hybrasyl.Castables
                 this._con = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Dex
@@ -843,7 +686,7 @@ namespace Hybrasyl.Castables
                 this._dex = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(0)]
         public int Hp
@@ -857,7 +700,7 @@ namespace Hybrasyl.Castables
                 this._hp = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(0)]
         public int Mp
@@ -871,7 +714,7 @@ namespace Hybrasyl.Castables
                 this._mp = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Hit
@@ -885,7 +728,7 @@ namespace Hybrasyl.Castables
                 this._hit = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Dmg
@@ -899,7 +742,7 @@ namespace Hybrasyl.Castables
                 this._dmg = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Ac
@@ -913,7 +756,7 @@ namespace Hybrasyl.Castables
                 this._ac = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Regen
@@ -927,7 +770,7 @@ namespace Hybrasyl.Castables
                 this._regen = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(sbyte), "0")]
         public sbyte Mr
@@ -941,7 +784,7 @@ namespace Hybrasyl.Castables
                 this._mr = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public Element OffensiveElement
         {
@@ -954,7 +797,7 @@ namespace Hybrasyl.Castables
                 this._offensiveElement = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public Element DefensiveElement
         {
@@ -967,60 +810,201 @@ namespace Hybrasyl.Castables
                 this._defensiveElement = value;
             }
         }
+        
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public float DamageModifier
+        {
+            get
+            {
+                return this._damageModifier;
+            }
+            set
+            {
+                this._damageModifier = value;
+            }
+        }
+        
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public float HealModifier
+        {
+            get
+            {
+                return this._healModifier;
+            }
+            set
+            {
+                this._healModifier = value;
+            }
+        }
+        
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public DamageType DamageType
+        {
+            get
+            {
+                return this._damageType;
+            }
+            set
+            {
+                this._damageType = value;
+            }
+        }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public enum Element
     {
-
+        
         /// <remarks/>
         None,
-
+        
         /// <remarks/>
         Fire,
-
+        
         /// <remarks/>
         Water,
-
+        
         /// <remarks/>
         Wind,
-
+        
         /// <remarks/>
         Earth,
-
+        
         /// <remarks/>
         Light,
-
+        
         /// <remarks/>
         Dark,
-
+        
         /// <remarks/>
         Wood,
-
+        
         /// <remarks/>
         Metal,
-
+        
         /// <remarks/>
         Undead,
-
+        
         /// <remarks/>
         Random,
     }
-
+    
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
+    [System.SerializableAttribute()]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/HybrasylCommon")]
+    public enum DamageType
+    {
+        
+        /// <remarks/>
+        Direct,
+        
+        /// <remarks/>
+        Physical,
+        
+        /// <remarks/>
+        Magical,
+        
+        /// <remarks/>
+        Elemental,
+    }
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
+    public partial class AddStatus
+    {
+        
+        private List<StatusStatEffects> _statEffects;
+        
+        private Conditions _conditions;
+        
+        private ushort _icon;
+        
+        private int _duration;
+        
+        private int _tick;
+        
+        [System.Xml.Serialization.XmlElementAttribute("StatEffects")]
+        public List<StatusStatEffects> StatEffects
+        {
+            get
+            {
+                return this._statEffects;
+            }
+            set
+            {
+                this._statEffects = value;
+            }
+        }
+        
+        public Conditions Conditions
+        {
+            get
+            {
+                return this._conditions;
+            }
+            set
+            {
+                this._conditions = value;
+            }
+        }
+        
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public ushort Icon
+        {
+            get
+            {
+                return this._icon;
+            }
+            set
+            {
+                this._icon = value;
+            }
+        }
+        
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public int Duration
+        {
+            get
+            {
+                return this._duration;
+            }
+            set
+            {
+                this._duration = value;
+            }
+        }
+        
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public int Tick
+        {
+            get
+            {
+                return this._tick;
+            }
+            set
+            {
+                this._tick = value;
+            }
+        }
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
+    [System.SerializableAttribute()]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.ComponentModel.DesignerCategoryAttribute("code")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class Statuses
     {
-
+        
         private List<AddStatus> _add;
-
+        
         private List<RemoveStatus> _remove;
-
+        
         [System.Xml.Serialization.XmlElementAttribute("Add")]
         public List<AddStatus> Add
         {
@@ -1033,7 +1017,7 @@ namespace Hybrasyl.Castables
                 this._add = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlElementAttribute("Remove")]
         public List<RemoveStatus> Remove
         {
@@ -1047,32 +1031,32 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class Damage
     {
-
+        
         private DamageFlags _flags;
-
+        
         private SimpleQuantity _simple;
-
+        
         private string _formula;
-
+        
         private bool _timeBased;
-
+        
         private uint _duration;
-
+        
         private DamageType _type;
-
+        
         public Damage()
         {
             this._simple = new SimpleQuantity();
         }
-
+        
         public DamageFlags Flags
         {
             get
@@ -1084,7 +1068,7 @@ namespace Hybrasyl.Castables
                 this._flags = value;
             }
         }
-
+        
         public SimpleQuantity Simple
         {
             get
@@ -1096,7 +1080,7 @@ namespace Hybrasyl.Castables
                 this._simple = value;
             }
         }
-
+        
         public string Formula
         {
             get
@@ -1108,7 +1092,7 @@ namespace Hybrasyl.Castables
                 this._formula = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public bool TimeBased
         {
@@ -1121,7 +1105,7 @@ namespace Hybrasyl.Castables
                 this._timeBased = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public uint Duration
         {
@@ -1134,7 +1118,7 @@ namespace Hybrasyl.Castables
                 this._duration = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public DamageType Type
         {
@@ -1148,43 +1132,43 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.FlagsAttribute()]
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.hybrasyl.com/XML/Actions")]
     public enum DamageFlags
     {
-
+        
         /// <remarks/>
         Scaled = 1,
-
+        
         /// <remarks/>
         Resistance = 2,
-
+        
         /// <remarks/>
         Threat = 4,
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class SimpleQuantity
     {
-
+        
         private string _min;
-
+        
         private string _max;
-
+        
         public SimpleQuantity()
         {
             this._min = "0";
             this._max = "0";
         }
-
-        [System.Xml.Serialization.XmlAttributeAttribute(DataType = "nonNegativeInteger")]
+        
+        [System.Xml.Serialization.XmlAttributeAttribute(DataType="nonNegativeInteger")]
         [System.ComponentModel.DefaultValueAttribute("0")]
         public string Min
         {
@@ -1197,8 +1181,8 @@ namespace Hybrasyl.Castables
                 this._min = value;
             }
         }
-
-        [System.Xml.Serialization.XmlAttributeAttribute(DataType = "nonNegativeInteger")]
+        
+        [System.Xml.Serialization.XmlAttributeAttribute(DataType="nonNegativeInteger")]
         [System.ComponentModel.DefaultValueAttribute("0")]
         public string Max
         {
@@ -1212,47 +1196,28 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
-    [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/HybrasylCommon")]
-    public enum DamageType
-    {
-
-        /// <remarks/>
-        Direct,
-
-        /// <remarks/>
-        Physical,
-
-        /// <remarks/>
-        Magical,
-
-        /// <remarks/>
-        Elemental,
-    }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class Heal
     {
-
+        
         private SimpleQuantity _simple;
-
+        
         private string _formula;
-
+        
         private bool _timeBased;
-
+        
         private uint _duration;
-
+        
         public Heal()
         {
             this._simple = new SimpleQuantity();
         }
-
+        
         public SimpleQuantity Simple
         {
             get
@@ -1264,7 +1229,7 @@ namespace Hybrasyl.Castables
                 this._simple = value;
             }
         }
-
+        
         public string Formula
         {
             get
@@ -1276,7 +1241,7 @@ namespace Hybrasyl.Castables
                 this._formula = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public bool TimeBased
         {
@@ -1289,7 +1254,7 @@ namespace Hybrasyl.Castables
                 this._timeBased = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public uint Duration
         {
@@ -1303,26 +1268,26 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class AnimationDuration
     {
-
+        
         private ushort _id;
-
+        
         private ushort _speed;
-
+        
         private uint _tick;
-
+        
         public AnimationDuration()
         {
             this._speed = ((ushort)(100));
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public ushort Id
         {
@@ -1335,7 +1300,7 @@ namespace Hybrasyl.Castables
                 this._id = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(ushort), "100")]
         public ushort Speed
@@ -1349,7 +1314,7 @@ namespace Hybrasyl.Castables
                 this._speed = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public uint Tick
         {
@@ -1363,21 +1328,21 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class AnimationDurationGroup
     {
-
+        
         private AnimationDuration _player;
-
+        
         private AnimationDuration _spellEffect;
-
+        
         private AnimationDuration _target;
-
+        
         public AnimationDuration Player
         {
             get
@@ -1389,7 +1354,7 @@ namespace Hybrasyl.Castables
                 this._player = value;
             }
         }
-
+        
         public AnimationDuration SpellEffect
         {
             get
@@ -1401,7 +1366,7 @@ namespace Hybrasyl.Castables
                 this._spellEffect = value;
             }
         }
-
+        
         public AnimationDuration Target
         {
             get
@@ -1414,24 +1379,24 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class Animation
     {
-
+        
         private ushort _id;
-
+        
         private ushort _speed;
-
+        
         public Animation()
         {
             this._speed = ((ushort)(100));
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public ushort Id
         {
@@ -1444,7 +1409,7 @@ namespace Hybrasyl.Castables
                 this._id = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(ushort), "100")]
         public ushort Speed
@@ -1459,26 +1424,26 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class Motion
     {
-
+        
         private List<Class> _class;
-
+        
         private int _id;
-
+        
         private int _speed;
-
+        
         public Motion()
         {
             this._class = new List<Class>();
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<Class> Class
         {
@@ -1491,7 +1456,7 @@ namespace Hybrasyl.Castables
                 this._class = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public int Id
         {
@@ -1504,7 +1469,7 @@ namespace Hybrasyl.Castables
                 this._id = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public int Speed
         {
@@ -1518,34 +1483,34 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class AnimationGroup
     {
-
-        private List<Motion> _motions;
-
+        
+        private List<Motion> _player;
+        
         private Animation _spellEffect;
-
+        
         private Animation _target;
-
-        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable = false)]
-        public List<Motion> Motions
+        
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
+        public List<Motion> Player
         {
             get
             {
-                return this._motions;
+                return this._player;
             }
             set
             {
-                this._motions = value;
+                this._player = value;
             }
         }
-
+        
         public Animation SpellEffect
         {
             get
@@ -1557,7 +1522,7 @@ namespace Hybrasyl.Castables
                 this._spellEffect = value;
             }
         }
-
+        
         public Animation Target
         {
             get
@@ -1570,21 +1535,21 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class Animations
     {
-
+        
         private AnimationGroup _onCast;
-
-        private AnimationDurationGroup _duration;
-
-        private AnimationGroup _end;
-
+        
+        private AnimationDurationGroup _onTick;
+        
+        private AnimationDurationGroup _onEnd;
+        
         public AnimationGroup OnCast
         {
             get
@@ -1596,60 +1561,60 @@ namespace Hybrasyl.Castables
                 this._onCast = value;
             }
         }
-
-        public AnimationDurationGroup Duration
+        
+        public AnimationDurationGroup OnTick
         {
             get
             {
-                return this._duration;
+                return this._onTick;
             }
             set
             {
-                this._duration = value;
+                this._onTick = value;
             }
         }
-
-        public AnimationGroup End
+        
+        public AnimationDurationGroup OnEnd
         {
             get
             {
-                return this._end;
+                return this._onEnd;
             }
             set
             {
-                this._end = value;
+                this._onEnd = value;
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class Effects
     {
-
+        
         private Animations _animations;
-
+        
         private EffectsSound _sound;
-
+        
         private Heal _heal;
-
+        
         private Damage _damage;
-
+        
         private List<StatEffect> _statEffects;
-
+        
         private Statuses _statuses;
-
+        
         private bool _scriptOverride;
-
+        
         public Effects()
         {
             this._statuses = new Statuses();
             this._scriptOverride = false;
         }
-
+        
         public Animations Animations
         {
             get
@@ -1661,7 +1626,7 @@ namespace Hybrasyl.Castables
                 this._animations = value;
             }
         }
-
+        
         public EffectsSound Sound
         {
             get
@@ -1673,7 +1638,7 @@ namespace Hybrasyl.Castables
                 this._sound = value;
             }
         }
-
+        
         public Heal Heal
         {
             get
@@ -1685,7 +1650,7 @@ namespace Hybrasyl.Castables
                 this._heal = value;
             }
         }
-
+        
         public Damage Damage
         {
             get
@@ -1697,8 +1662,8 @@ namespace Hybrasyl.Castables
                 this._damage = value;
             }
         }
-
-        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable = false)]
+        
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
         public List<StatEffect> StatEffects
         {
             get
@@ -1710,7 +1675,7 @@ namespace Hybrasyl.Castables
                 this._statEffects = value;
             }
         }
-
+        
         public Statuses Statuses
         {
             get
@@ -1722,7 +1687,7 @@ namespace Hybrasyl.Castables
                 this._statuses = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(false)]
         public bool ScriptOverride
@@ -1737,17 +1702,17 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class EffectsSound
     {
-
+        
         private byte _id;
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Id
         {
@@ -1761,25 +1726,25 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class Restrictions
     {
-
+        
         private List<WeaponType> _weaponType;
-
+        
         private List<EquipmentSlot> _equipType;
-
+        
         public Restrictions()
         {
             this._equipType = new List<EquipmentSlot>();
             this._weaponType = new List<WeaponType>();
         }
-
+        
         [System.Xml.Serialization.XmlElementAttribute("WeaponType")]
         public List<WeaponType> WeaponType
         {
@@ -1792,7 +1757,7 @@ namespace Hybrasyl.Castables
                 this._weaponType = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlElementAttribute("EquipType")]
         public List<EquipmentSlot> EquipType
         {
@@ -1806,116 +1771,116 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/HybrasylCommon")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/HybrasylCommon")]
     public enum WeaponType
     {
-
+        
         /// <remarks/>
         OneHand,
-
+        
         /// <remarks/>
         TwoHand,
-
+        
         /// <remarks/>
         Dagger,
-
+        
         /// <remarks/>
         Staff,
-
+        
         /// <remarks/>
         Claw,
-
+        
         /// <remarks/>
         None,
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/HybrasylCommon")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/HybrasylCommon")]
     public enum EquipmentSlot
     {
-
+        
         /// <remarks/>
         None,
-
+        
         /// <remarks/>
         Weapon,
-
+        
         /// <remarks/>
         Armor,
-
+        
         /// <remarks/>
         Shield,
-
+        
         /// <remarks/>
         Helmet,
-
+        
         /// <remarks/>
         Earring,
-
+        
         /// <remarks/>
         Necklace,
-
+        
         /// <remarks/>
         LeftHand,
-
+        
         /// <remarks/>
         RightHand,
-
+        
         /// <remarks/>
         LeftArm,
-
+        
         /// <remarks/>
         RightArm,
-
+        
         /// <remarks/>
         Waist,
-
+        
         /// <remarks/>
         Leg,
-
+        
         /// <remarks/>
         Foot,
-
+        
         /// <remarks/>
         FirstAcc,
-
+        
         /// <remarks/>
         Trousers,
-
+        
         /// <remarks/>
         Coat,
-
+        
         /// <remarks/>
         SecondAcc,
-
+        
         /// <remarks/>
         ThirdAcc,
-
+        
         /// <remarks/>
         Gauntlet,
-
+        
         /// <remarks/>
         Ring,
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class LearnPrerequisite
     {
-
+        
         private byte _level;
-
+        
         private byte _ab;
-
+        
         private string _value;
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Level
         {
@@ -1928,7 +1893,7 @@ namespace Hybrasyl.Castables
                 this._level = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Ab
         {
@@ -1941,7 +1906,7 @@ namespace Hybrasyl.Castables
                 this._ab = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlTextAttribute()]
         public string Value
         {
@@ -1955,33 +1920,33 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(Requirement))]
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class ClassRequirement
     {
-
+        
         private ClassRequirementLevel _level;
-
+        
         private ClassRequirementAB _ab;
-
+        
         private List<ItemSpecification> _items;
-
+        
         private uint _gold;
-
+        
         private ClassRequirementPhysical _physical;
-
+        
         private List<LearnPrerequisite> _prerequisites;
-
+        
         public ClassRequirement()
         {
             this._prerequisites = new List<LearnPrerequisite>();
         }
-
+        
         public ClassRequirementLevel Level
         {
             get
@@ -1993,7 +1958,7 @@ namespace Hybrasyl.Castables
                 this._level = value;
             }
         }
-
+        
         public ClassRequirementAB Ab
         {
             get
@@ -2005,8 +1970,8 @@ namespace Hybrasyl.Castables
                 this._ab = value;
             }
         }
-
-        [System.Xml.Serialization.XmlArrayItemAttribute("Item", IsNullable = false)]
+        
+        [System.Xml.Serialization.XmlArrayItemAttribute("Item", IsNullable=false)]
         public List<ItemSpecification> Items
         {
             get
@@ -2018,7 +1983,7 @@ namespace Hybrasyl.Castables
                 this._items = value;
             }
         }
-
+        
         public uint Gold
         {
             get
@@ -2030,7 +1995,7 @@ namespace Hybrasyl.Castables
                 this._gold = value;
             }
         }
-
+        
         public ClassRequirementPhysical Physical
         {
             get
@@ -2042,8 +2007,8 @@ namespace Hybrasyl.Castables
                 this._physical = value;
             }
         }
-
-        [System.Xml.Serialization.XmlArrayItemAttribute("Prerequisite", IsNullable = false)]
+        
+        [System.Xml.Serialization.XmlArrayItemAttribute("Prerequisite", IsNullable=false)]
         public List<LearnPrerequisite> Prerequisites
         {
             get
@@ -2056,25 +2021,25 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class ClassRequirementLevel
     {
-
+        
         private byte _min;
-
+        
         private byte _max;
-
+        
         public ClassRequirementLevel()
         {
             this._min = ((byte)(0));
             this._max = ((byte)(255));
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Min
@@ -2088,7 +2053,7 @@ namespace Hybrasyl.Castables
                 this._min = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "255")]
         public byte Max
@@ -2103,25 +2068,25 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class ClassRequirementAB
     {
-
+        
         private byte _min;
-
+        
         private byte _max;
-
+        
         public ClassRequirementAB()
         {
             this._min = ((byte)(0));
             this._max = ((byte)(255));
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Min
@@ -2135,7 +2100,7 @@ namespace Hybrasyl.Castables
                 this._min = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "255")]
         public byte Max
@@ -2150,24 +2115,24 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class ItemSpecification
     {
-
+        
         private byte _quantity;
-
+        
         private string _value;
-
+        
         public ItemSpecification()
         {
             this._quantity = ((byte)(1));
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "1")]
         public byte Quantity
@@ -2181,7 +2146,7 @@ namespace Hybrasyl.Castables
                 this._quantity = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlTextAttribute()]
         public string Value
         {
@@ -2195,29 +2160,29 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class ClassRequirementPhysical
     {
-
+        
         private byte _str;
-
+        
         private byte _int;
-
+        
         private byte _wis;
-
+        
         private byte _con;
-
+        
         private byte _dex;
-
+        
         private uint _hp;
-
+        
         private uint _mp;
-
+        
         public ClassRequirementPhysical()
         {
             this._str = ((byte)(0));
@@ -2228,7 +2193,7 @@ namespace Hybrasyl.Castables
             this._hp = ((uint)(0));
             this._mp = ((uint)(0));
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Str
@@ -2242,7 +2207,7 @@ namespace Hybrasyl.Castables
                 this._str = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Int
@@ -2256,7 +2221,7 @@ namespace Hybrasyl.Castables
                 this._int = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Wis
@@ -2270,7 +2235,7 @@ namespace Hybrasyl.Castables
                 this._wis = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Con
@@ -2284,7 +2249,7 @@ namespace Hybrasyl.Castables
                 this._con = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Dex
@@ -2298,7 +2263,7 @@ namespace Hybrasyl.Castables
                 this._dex = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(uint), "0")]
         public uint Hp
@@ -2312,7 +2277,7 @@ namespace Hybrasyl.Castables
                 this._hp = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(uint), "0")]
         public uint Mp
@@ -2327,22 +2292,22 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class Requirement : ClassRequirement
     {
-
+        
         private List<Class> _class;
-
+        
         public Requirement()
         {
             this._class = new List<Class>();
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<Class> Class
         {
@@ -2356,27 +2321,27 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class MaxLevel
     {
-
+        
         private byte _monk;
-
+        
         private byte _warrior;
-
+        
         private byte _peasant;
-
+        
         private byte _wizard;
-
+        
         private byte _priest;
-
+        
         private byte _rogue;
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Monk
         {
@@ -2389,7 +2354,7 @@ namespace Hybrasyl.Castables
                 this._monk = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Warrior
         {
@@ -2402,7 +2367,7 @@ namespace Hybrasyl.Castables
                 this._warrior = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Peasant
         {
@@ -2415,7 +2380,7 @@ namespace Hybrasyl.Castables
                 this._peasant = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Wizard
         {
@@ -2428,7 +2393,7 @@ namespace Hybrasyl.Castables
                 this._wizard = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Priest
         {
@@ -2441,7 +2406,7 @@ namespace Hybrasyl.Castables
                 this._priest = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public byte Rogue
         {
@@ -2455,25 +2420,25 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class Intent
     {
-
+        
         private SpellUseType _useType;
-
+        
         private byte _radius;
-
+        
         private IntentDirection _direction;
-
+        
         private List<IntentTarget> _target;
-
+        
         private byte _maxTargets;
-
+        
         public Intent()
         {
             this._target = new List<IntentTarget>();
@@ -2482,7 +2447,7 @@ namespace Hybrasyl.Castables
             this._direction = IntentDirection.Front;
             this._maxTargets = ((byte)(0));
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(SpellUseType.NoTarget)]
         public SpellUseType UseType
@@ -2496,7 +2461,7 @@ namespace Hybrasyl.Castables
                 this._useType = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte Radius
@@ -2510,7 +2475,7 @@ namespace Hybrasyl.Castables
                 this._radius = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(IntentDirection.Front)]
         public IntentDirection Direction
@@ -2524,7 +2489,7 @@ namespace Hybrasyl.Castables
                 this._direction = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<IntentTarget> Target
         {
@@ -2537,7 +2502,7 @@ namespace Hybrasyl.Castables
                 this._target = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(typeof(byte), "0")]
         public byte MaxTargets
@@ -2552,95 +2517,95 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public enum SpellUseType
     {
-
+        
         /// <remarks/>
         Unusable,
-
+        
         /// <remarks/>
         Prompt,
-
+        
         /// <remarks/>
         Target,
-
+        
         /// <remarks/>
         FourDigit,
-
+        
         /// <remarks/>
         ThreeDigit,
-
+        
         /// <remarks/>
         NoTarget,
-
+        
         /// <remarks/>
         TwoDigit,
-
+        
         /// <remarks/>
         Onedigit,
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public enum IntentDirection
     {
-
+        
         /// <remarks/>
         Front,
-
+        
         /// <remarks/>
         Back,
-
+        
         /// <remarks/>
         Left,
-
+        
         /// <remarks/>
         Right,
-
+        
         /// <remarks/>
         Nearby,
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public enum IntentTarget
     {
-
+        
         /// <remarks/>
         Hostile,
-
+        
         /// <remarks/>
         Friendly,
-
+        
         /// <remarks/>
         Pvp,
-
+        
         /// <remarks/>
         Group,
     }
-
+    
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(CastCost))]
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class ClassCastCost
     {
-
+        
         private List<ItemSpecification> _items;
-
+        
         private ClassCastCostStat _stat;
-
+        
         private uint _gold;
-
-        [System.Xml.Serialization.XmlArrayItemAttribute("Item", IsNullable = false)]
+        
+        [System.Xml.Serialization.XmlArrayItemAttribute("Item", IsNullable=false)]
         public List<ItemSpecification> Items
         {
             get
@@ -2652,7 +2617,7 @@ namespace Hybrasyl.Castables
                 this._items = value;
             }
         }
-
+        
         public ClassCastCostStat Stat
         {
             get
@@ -2664,7 +2629,7 @@ namespace Hybrasyl.Castables
                 this._stat = value;
             }
         }
-
+        
         public uint Gold
         {
             get
@@ -2677,25 +2642,25 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true, Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class ClassCastCostStat
     {
-
+        
         private string _hp;
-
+        
         private string _mp;
-
+        
         public ClassCastCostStat()
         {
             this._hp = "0";
             this._mp = "0";
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute("0")]
         public string Hp
@@ -2709,7 +2674,7 @@ namespace Hybrasyl.Castables
                 this._hp = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute("0")]
         public string Mp
@@ -2724,22 +2689,22 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class CastCost : ClassCastCost
     {
-
+        
         private List<Class> _class;
-
+        
         public CastCost()
         {
             this._class = new List<Class>();
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public List<Class> Class
         {
@@ -2753,22 +2718,22 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class CastCostList
     {
-
+        
         private CastCost _castCost;
-
+        
         public CastCostList()
         {
             this._castCost = new CastCost();
         }
-
+        
         public CastCost CastCost
         {
             get
@@ -2781,24 +2746,24 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class Category
     {
-
+        
         private bool _unique;
-
+        
         private string _value;
-
+        
         public Category()
         {
             this._unique = false;
         }
-
+        
         [System.Xml.Serialization.XmlAttributeAttribute()]
         [System.ComponentModel.DefaultValueAttribute(false)]
         public bool Unique
@@ -2812,7 +2777,7 @@ namespace Hybrasyl.Castables
                 this._unique = value;
             }
         }
-
+        
         [System.Xml.Serialization.XmlTextAttribute()]
         public string Value
         {
@@ -2826,22 +2791,22 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public partial class Categories
     {
-
+        
         private Category _category;
-
+        
         public Categories()
         {
             this._category = new Category();
         }
-
+        
         public Category Category
         {
             get
@@ -2854,28 +2819,28 @@ namespace Hybrasyl.Castables
             }
         }
     }
-
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Actions")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://www.hybrasyl.com/XML/Actions")]
     public enum Book
     {
-
+        
         /// <remarks/>
         PrimarySkill,
-
+        
         /// <remarks/>
         SecondarySkill,
-
+        
         /// <remarks/>
         UtilitySkill,
-
+        
         /// <remarks/>
         PrimarySpell,
-
+        
         /// <remarks/>
         SecondarySpell,
-
+        
         /// <remarks/>
         UtilitySpell,
     }

--- a/HybrasylIntegration/HybrasylXML/XSD/Castables.xsd
+++ b/HybrasylIntegration/HybrasylXML/XSD/Castables.xsd
@@ -324,15 +324,15 @@
   <xs:complexType name="Animations">
     <xs:sequence minOccurs="0" maxOccurs="1">
       <xs:element name="OnCast" type="actions:AnimationGroup" minOccurs="0" maxOccurs="1" />
-      <xs:element name="Duration" type="actions:AnimationDurationGroup" minOccurs="0" maxOccurs="1" />
-      <xs:element name="End" type="actions:AnimationGroup" minOccurs="0" maxOccurs="1" />
+      <xs:element name="OnTick" type="actions:AnimationDurationGroup" minOccurs="0" maxOccurs="1" />
+      <xs:element name="OnEnd" type="actions:AnimationDurationGroup" minOccurs="0" maxOccurs="1" />
     </xs:sequence>
   </xs:complexType>
 
   <!-- Animation group -->
   <xs:complexType name="AnimationGroup">
     <xs:sequence minOccurs="0" maxOccurs="1">
-      <xs:element name="Motions" type="actions:MotionsList" minOccurs="0" maxOccurs="1" />
+      <xs:element name="Player" type="actions:MotionsList" minOccurs="0" maxOccurs="1" />
       <xs:element name="SpellEffect" type="actions:Animation" minOccurs="0" maxOccurs="1" />
       <xs:element name="Target" type="actions:Animation" minOccurs="0" maxOccurs="1" />
     </xs:sequence>
@@ -376,7 +376,7 @@
     </xs:sequence>
     <xs:attribute name="ScriptOverride" type="xs:boolean" default="false"/>
   </xs:complexType>
-
+    
   <xs:complexType name="Categories">
     <xs:sequence minOccurs="0" maxOccurs="1">
       <xs:element name="Category" type="actions:Category"/>
@@ -391,20 +391,6 @@
     </xs:simpleContent>
   </xs:complexType>
 
-  <xs:complexType name="StatusAnimations">
-    <xs:sequence>
-      <xs:element name="OnTick" type="actions:StatusAnimation" minOccurs="0" maxOccurs="1" />
-      <xs:element name="OnStart" type="actions:StatusAnimation" minOccurs="0" maxOccurs="1" />
-      <xs:element name="OnEnd" type="actions:StatusAnimation" minOccurs="0" maxOccurs="1" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="StatusAnimation">
-    <xs:attribute name="TargetEffect" type="xs:unsignedShort" use="optional"/>
-    <xs:attribute name="CasterEffect" type="xs:unsignedShort" use="optional"/>
-    <xs:attribute name="Message" type="hyb:String8" use="optional"/>
-  </xs:complexType>
-
   <xs:complexType name="Conditions">
     <xs:sequence>
       <xs:element name="Add" type="hyb:ConditionList" minOccurs="0" maxOccurs="1"/>
@@ -414,8 +400,7 @@
   
   <xs:complexType name="AddStatus">
     <xs:sequence>
-      <xs:element name="StatEffect" type="actions:StatEffect" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element name="Animations" type="actions:StatusAnimations" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="StatEffects" type="actions:StatusStatEffects" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="Conditions" type="actions:Conditions" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
     <xs:attribute name="Icon" type="xs:unsignedShort" use="required"/>
@@ -423,6 +408,13 @@
     <xs:attribute name="Tick" type="xs:int" use="required"/>
   </xs:complexType>
 
+  <xs:complexType name="StatusStatEffects">
+    <xs:sequence>
+      <xs:element name="OnCast" type="actions:StatEffects" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="OnTick" type="actions:StatEffects" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  
   <xs:complexType name="RemoveStatus">
     <xs:attribute name="Icon" type="xs:unsignedShort" />
     <xs:attribute name="Name" type="hyb:String8"/>
@@ -457,6 +449,9 @@
     <xs:attribute name="Mr" default="0" type="xs:byte" />
     <xs:attribute name="OffensiveElement" type="actions:Element"/>
     <xs:attribute name="DefensiveElement" type="actions:Element"/>
+    <xs:attribute name="DamageModifier" type="xs:float"/>
+    <xs:attribute name="HealModifier" type="xs:float"/>
+    <xs:attribute name="DamageType" type="hyb:DamageType"/>
   </xs:complexType>
 
   <!-- Restrictions on casting, such as types of equipment, or

--- a/HybrasylIntegration/HybrasylXML/XSD/Castables.xsd
+++ b/HybrasylIntegration/HybrasylXML/XSD/Castables.xsd
@@ -493,7 +493,7 @@
       <xs:element name="Requirements" type="actions:Requirements" minOccurs="0" maxOccurs="1" />
       <xs:element name="Restrictions" type="actions:Restrictions" minOccurs="0" maxOccurs="1" />
       <xs:element name="Effects" type="actions:Effects" minOccurs="0" maxOccurs="1" />
-      <xs:element name="Script" type="hyb:String8" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="Script" type="xs:string" minOccurs="0" maxOccurs="1"/>
     </xs:all>
     <!-- Castable attributes -->
     <xs:attribute name="Type" use="required" />

--- a/HybrasylIntegration/HybrasylXML/XSD/Castables.xsd
+++ b/HybrasylIntegration/HybrasylXML/XSD/Castables.xsd
@@ -369,13 +369,12 @@
           <xs:attribute name="Id" type="xs:unsignedByte" use="required" />
         </xs:complexType>
       </xs:element>
-      <xs:element name="Script" minOccurs="0" maxOccurs="1" type="hyb:String8" />
       <xs:element name="Heal" minOccurs="0" maxOccurs="1" type="actions:Heal" />
       <xs:element name="Damage" minOccurs="0" maxOccurs="1" type="actions:Damage" />
       <xs:element name="StatEffects" minOccurs="0" maxOccurs="1" type="actions:StatEffects" />
       <xs:element name="Statuses" minOccurs="0" maxOccurs="0" type="actions:Statuses" />
     </xs:sequence>
-    <xs:attribute name="Duration" type="xs:unsignedInt" />
+    <xs:attribute name="ScriptOverride" type="xs:boolean" default="false"/>
   </xs:complexType>
 
   <xs:complexType name="Categories">
@@ -405,11 +404,19 @@
     <xs:attribute name="CasterEffect" type="xs:unsignedShort" use="optional"/>
     <xs:attribute name="Message" type="hyb:String8" use="optional"/>
   </xs:complexType>
-    
+
+  <xs:complexType name="Conditions">
+    <xs:sequence>
+      <xs:element name="Add" type="hyb:ConditionList" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="Remove" type="hyb:ConditionList" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  
   <xs:complexType name="AddStatus">
     <xs:sequence>
       <xs:element name="StatEffect" type="actions:StatEffect" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="Animations" type="actions:StatusAnimations" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="Conditions" type="actions:Conditions" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
     <xs:attribute name="Icon" type="xs:unsignedShort" use="required"/>
     <xs:attribute name="Duration" type="xs:int" use="required"/>
@@ -491,6 +498,7 @@
       <xs:element name="Requirements" type="actions:Requirements" minOccurs="0" maxOccurs="1" />
       <xs:element name="Restrictions" type="actions:Restrictions" minOccurs="0" maxOccurs="1" />
       <xs:element name="Effects" type="actions:Effects" minOccurs="0" maxOccurs="1" />
+      <xs:element name="Script" type="hyb:String8" minOccurs="0" maxOccurs="1"/>
     </xs:all>
     <!-- Castable attributes -->
     <xs:attribute name="Type" use="required" />

--- a/HybrasylIntegration/HybrasylXML/XSD/Creatures.Designer.cs
+++ b/HybrasylIntegration/HybrasylXML/XSD/Creatures.Designer.cs
@@ -17,7 +17,7 @@ namespace Hybrasyl.Creatures
     using System.Collections.Generic;
 
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -164,7 +164,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -203,7 +203,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Creature")]
     public enum ScriptType
@@ -216,7 +216,7 @@ namespace Hybrasyl.Creatures
         Supplement,
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -295,7 +295,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -342,7 +342,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -438,7 +438,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -514,7 +514,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -538,7 +538,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -615,7 +615,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -750,7 +750,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -829,7 +829,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/HybrasylCommon")]
     public enum Element
@@ -869,7 +869,7 @@ namespace Hybrasyl.Creatures
         Random,
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -916,7 +916,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -1025,7 +1025,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/HybrasylCommon")]
     public enum DamageType
@@ -1044,7 +1044,7 @@ namespace Hybrasyl.Creatures
         Elemental,
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -1121,7 +1121,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -1160,7 +1160,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/HybrasylCommon")]
     public enum IntentType
@@ -1176,7 +1176,7 @@ namespace Hybrasyl.Creatures
         Neutral,
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -1230,7 +1230,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -1276,7 +1276,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -1360,7 +1360,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -1413,7 +1413,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -1523,7 +1523,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -1562,7 +1562,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -1643,7 +1643,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -1653,9 +1653,14 @@ namespace Hybrasyl.Creatures
 
         private string _type;
 
-        private Class _class;
+        private List<Class> _class;
 
         private string _name;
+
+        public NpcRoleTrainCastable()
+        {
+            this._class = new List<Class>();
+        }
 
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public string Type
@@ -1671,7 +1676,7 @@ namespace Hybrasyl.Creatures
         }
 
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        public Class Class
+        public List<Class> Class
         {
             get
             {
@@ -1697,7 +1702,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/HybrasylCommon")]
     public enum Class
@@ -1722,7 +1727,7 @@ namespace Hybrasyl.Creatures
         Monk,
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -1776,7 +1781,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -1820,7 +1825,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -1859,7 +1864,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -1918,7 +1923,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/HybrasylCommon")]
     public enum NpcRepairType
@@ -1934,7 +1939,7 @@ namespace Hybrasyl.Creatures
         All,
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -1958,7 +1963,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
@@ -2000,7 +2005,7 @@ namespace Hybrasyl.Creatures
         }
     }
 
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1586.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1590.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]

--- a/HybrasylIntegration/HybrasylXML/XSD/Creatures.xsd
+++ b/HybrasylIntegration/HybrasylXML/XSD/Creatures.xsd
@@ -208,7 +208,7 @@
 
   <xs:complexType name="NpcRoleTrainCastable">
     <xs:attribute name="Type" type="hyb:String8"/>
-    <xs:attribute name="Class" use="optional">
+    <xs:attribute name="Class">
       <xs:simpleType>
         <xs:list itemType="hyb:Class" />
       </xs:simpleType>

--- a/HybrasylIntegration/HybrasylXML/XSD/Creatures.xsd
+++ b/HybrasylIntegration/HybrasylXML/XSD/Creatures.xsd
@@ -208,7 +208,11 @@
 
   <xs:complexType name="NpcRoleTrainCastable">
     <xs:attribute name="Type" type="hyb:String8"/>
-    <xs:attribute name="Class" type="hyb:Class"/>
+    <xs:attribute name="Class" use="optional">
+      <xs:simpleType>
+        <xs:list itemType="hyb:Class" />
+      </xs:simpleType>
+    </xs:attribute>
     <xs:attribute name="Name" type="hyb:String8"/>
   </xs:complexType>
   

--- a/HybrasylIntegration/HybrasylXML/XSD/hybrasylTypes.xsd
+++ b/HybrasylIntegration/HybrasylXML/XSD/hybrasylTypes.xsd
@@ -94,7 +94,7 @@
 
   <!-- Status effects -->
 
-  <xs:simpleType name="StatusEffectList">
+  <xs:simpleType name="ConditionList">
     <xs:restriction>
       <xs:simpleType>
         <xs:list>
@@ -104,7 +104,7 @@
               <xs:enumeration value="Sleep" />
               <xs:enumeration value="Paralyze" />
               <xs:enumeration value="Blind" />
-              <xs:enumeration value="Skull" />
+              <xs:enumeration value="Coma" />
               <xs:enumeration value="Poison" />
               <xs:enumeration value="Mist" />
               <xs:enumeration value="Regen" />


### PR DESCRIPTION
This PR adds "condition" support to XML statuses, e.g. poison, sleep, etc. This is a prerequisite to simplifying the existing statuses / flags / etc in Hybrasyl so that the vast majority of effects can be completely expressed in XML.

This PR also moves `Script` to the top level, and adds `ScriptOverride` as an attribute to `Effects`. If `ScriptOverride` is set to true, the script will be used for all the "entry points", e.g. `OnCast`, `OnTick`, `OnEnd` etc. This allows a castable to either use simple XML expressions or script more powerful interactions.

