### PR TITLE
disable automatic creation of AssemblyInfo

### DIFF
--- a/HybrasylIntegration/Entities/Entities.csproj
+++ b/HybrasylIntegration/Entities/Entities.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netstandard1.6</TargetFramework>
     <AssemblyName>Hybrasyl.Entities</AssemblyName>
     <RootNamespace>Hybrasyl.Entities</RootNamespace>
+    <Version>0.5.6</Version>
+    <PackageVersion>0.5.6</PackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='XML|AnyCPU'" />

--- a/HybrasylIntegration/HybrasylXML/Properties/AssemblyInfo.cs
+++ b/HybrasylIntegration/HybrasylXML/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Hybrasyl XML Library")]
+[assembly: AssemblyDescription("Hybrasyl data model library for XML-backed entities")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Project Hybrasyl")]
+[assembly: AssemblyProduct("Hybrasyl XML Library")]
+[assembly: AssemblyCopyright("(C) 2017 Project Hybrasyl")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("388625ea-db69-43f8-91cd-adb72ea9493b")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("0.5.6.*")]
+[assembly: AssemblyFileVersion("0.5.6.*")]

--- a/HybrasylIntegration/HybrasylXML/XML.csproj
+++ b/HybrasylIntegration/HybrasylXML/XML.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>Hybrasyl.XML</AssemblyName>
     <RootNamespace>Hybrasyl.XML</RootNamespace>
     <PackageVersion>0.5.6</PackageVersion>
+    <Version>0.5.6</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='XML|AnyCPU'" />

--- a/HybrasylIntegration/HybrasylXML/XML.csproj
+++ b/HybrasylIntegration/HybrasylXML/XML.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard1.6</TargetFramework>
     <AssemblyName>Hybrasyl.XML</AssemblyName>
     <RootNamespace>Hybrasyl.XML</RootNamespace>
+    <PackageVersion>0.5.6</PackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='XML|AnyCPU'" />

--- a/HybrasylIntegration/HybrasylXML/XML.csproj
+++ b/HybrasylIntegration/HybrasylXML/XML.csproj
@@ -10,6 +10,11 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Entities|AnyCPU'" />
 
+  <!-- Continue to control versioning manually with AssemblyInfo.cs -->
+  <PropertyGroup>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup> 
+ 
   <ItemGroup>
     <PackageReference Include="BinaryFormatter" Version="1.2.0" />
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />


### PR DESCRIPTION
This PR overrides the automatic creation of AssemblyInfo so that AppVeyor / other processes can manually generate it during the dotnet pack / build phase. It also sets a default in `*.csproj` so that it will be overridden correctly by the build process.

