### PR TITLE
Update to NET Standard 2.0 / fix `clone` functionality

### DIFF
--- a/HybrasylIntegration/Entities/Entities.csproj
+++ b/HybrasylIntegration/Entities/Entities.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Hybrasyl.Entities</AssemblyName>
     <RootNamespace>Hybrasyl.Entities</RootNamespace>
     <Version>0.5.6</Version>

--- a/HybrasylIntegration/HybrasylIntegration.sln
+++ b/HybrasylIntegration/HybrasylIntegration.sln
@@ -1,13 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.7
+VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 15.0.26403.3
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Integration", "HybrasylIntegration\Integration.csproj", "{1BCB1A3F-CD72-49A3-A962-C581685820F7}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IO", "IO\IO.csproj", "{BC0B3146-D1A2-4005-B0BD-5CBB2BBF76A4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Entities", "Entities\Entities.csproj", "{AEF48DA5-5DFF-4501-B306-28AEB1DD2371}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Entities", "Entities\Entities.csproj", "{AEF48DA5-5DFF-4501-B306-28AEB1DD2371}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XML", "HybrasylXML\XML.csproj", "{795D3BE0-7629-46A3-A124-1062117BFBF3}"
 EndProject
@@ -33,21 +33,25 @@ Global
 		{BC0B3146-D1A2-4005-B0BD-5CBB2BBF76A4}.XML|Any CPU.ActiveCfg = XML|Any CPU
 		{AEF48DA5-5DFF-4501-B306-28AEB1DD2371}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{AEF48DA5-5DFF-4501-B306-28AEB1DD2371}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{AEF48DA5-5DFF-4501-B306-28AEB1DD2371}.Entities|Any CPU.ActiveCfg = Entities|Any CPU
-		{AEF48DA5-5DFF-4501-B306-28AEB1DD2371}.Entities|Any CPU.Build.0 = Entities|Any CPU
+		{AEF48DA5-5DFF-4501-B306-28AEB1DD2371}.Entities|Any CPU.ActiveCfg = Release|Any CPU
+		{AEF48DA5-5DFF-4501-B306-28AEB1DD2371}.Entities|Any CPU.Build.0 = Release|Any CPU
 		{AEF48DA5-5DFF-4501-B306-28AEB1DD2371}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AEF48DA5-5DFF-4501-B306-28AEB1DD2371}.Release|Any CPU.Build.0 = Release|Any CPU
-		{AEF48DA5-5DFF-4501-B306-28AEB1DD2371}.XML|Any CPU.ActiveCfg = XML|Any CPU
+		{AEF48DA5-5DFF-4501-B306-28AEB1DD2371}.XML|Any CPU.ActiveCfg = Release|Any CPU
+		{AEF48DA5-5DFF-4501-B306-28AEB1DD2371}.XML|Any CPU.Build.0 = Release|Any CPU
 		{795D3BE0-7629-46A3-A124-1062117BFBF3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{795D3BE0-7629-46A3-A124-1062117BFBF3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{795D3BE0-7629-46A3-A124-1062117BFBF3}.Entities|Any CPU.ActiveCfg = Entities|Any CPU
-		{795D3BE0-7629-46A3-A124-1062117BFBF3}.Entities|Any CPU.Build.0 = Entities|Any CPU
+		{795D3BE0-7629-46A3-A124-1062117BFBF3}.Entities|Any CPU.ActiveCfg = Release|Any CPU
+		{795D3BE0-7629-46A3-A124-1062117BFBF3}.Entities|Any CPU.Build.0 = Release|Any CPU
 		{795D3BE0-7629-46A3-A124-1062117BFBF3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{795D3BE0-7629-46A3-A124-1062117BFBF3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{795D3BE0-7629-46A3-A124-1062117BFBF3}.XML|Any CPU.ActiveCfg = XML|Any CPU
-		{795D3BE0-7629-46A3-A124-1062117BFBF3}.XML|Any CPU.Build.0 = XML|Any CPU
+		{795D3BE0-7629-46A3-A124-1062117BFBF3}.XML|Any CPU.ActiveCfg = Release|Any CPU
+		{795D3BE0-7629-46A3-A124-1062117BFBF3}.XML|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {71FECD20-E67F-4702-BA10-72DB7BCF3CC2}
 	EndGlobalSection
 EndGlobal

--- a/HybrasylIntegration/HybrasylXML/Properties/AssemblyInfo.cs
+++ b/HybrasylIntegration/HybrasylXML/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.5.6.*")]
-[assembly: AssemblyFileVersion("0.5.6.*")]
+[assembly: AssemblyVersion("0.5.6.59")]
+[assembly: AssemblyFileVersion("0.5.6.59")]

--- a/HybrasylIntegration/HybrasylXML/XML.csproj
+++ b/HybrasylIntegration/HybrasylXML/XML.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Hybrasyl.XML</AssemblyName>
     <RootNamespace>Hybrasyl.XML</RootNamespace>
     <PackageVersion>0.5.6</PackageVersion>
@@ -18,7 +18,6 @@
   </PropertyGroup> 
  
   <ItemGroup>
-    <PackageReference Include="BinaryFormatter" Version="1.2.0" />
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />

--- a/HybrasylIntegration/HybrasylXML/XSD/hybrasylExtensions.cs
+++ b/HybrasylIntegration/HybrasylXML/XSD/hybrasylExtensions.cs
@@ -21,8 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
-//using System.Runtime.Serialization.Formatters.Binary;
-using BinaryFormatter;
+using System.Runtime.Serialization.Formatters.Binary;
 using System.Xml.Serialization;
 
 namespace Hybrasyl.Items
@@ -147,12 +146,13 @@ namespace Hybrasyl.Items
 
         public Item Clone()
         {
-            //MemoryStream ms = new MemoryStream();
-            BinaryConverter bf = new BinaryConverter();
-            var s = bf.Serialize(this);
-            var o = bf.Deserialize<Item>(s);
-            
-            return (Item)o;
+            MemoryStream ms = new MemoryStream();
+            BinaryFormatter bf = new BinaryFormatter();
+            bf.Serialize(ms, this);
+            ms.Position = 0;
+            object obj = bf.Deserialize(ms);
+            ms.Close();
+            return (Item)obj;
         }
     }
 }


### PR DESCRIPTION
This PR updates NET Standard to 2.0, which includes `BinaryFormatter`. We need to revert the changes to `Clone()` as they don't work, so this seemed like the best option. This also removes the other BinaryFormatter package.
